### PR TITLE
Remove double asterisk

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -88,8 +88,8 @@ tools must be tools Lint Review knows about. See [lint tools](#lint-tools) for a
 tools. A sample `.lintrc` file would look like.
 
     [files]
-    ignore = generated/**
-        vendor/**
+    ignore = generated/*
+        vendor/*
 
     [tools]
     linters = pep8, jshint


### PR DESCRIPTION
The doesn't asterisk doesn't seem to do anything:

```
>>> fnmatch.fnmatch("test/filename/python.py", "test/*")
True
>>> fnmatch.fnmatch("test/filename/python.py", "test/**")
True
```
