### PR TITLE
Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "lintreview"
-VERSION = "0.0.3"
+VERSION = "0.0.4"
 
 requirements = open('./requirements.txt', 'r')
 


### PR DESCRIPTION
We probably should have bumped the version in: https://github.com/markstory/lint-review/pull/27 or https://github.com/markstory/lint-review/pull/28
