### PR TITLE
Suppress PHP errors.

### DIFF
--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -33,7 +33,8 @@ class Phpcs(Tool):
         command = self.create_command(files)
         output = run_command(
             command,
-            ignore_error=True)
+            ignore_error=True,
+            include_errors=False)
         filename_converter = functools.partial(
             self._relativize_filename,
             files)


### PR DESCRIPTION
"PHP Deprecated" errors are being passed to ElementTree and it errors
out because the errors aren't in XML.
