### PR TITLE
Detect use of unsafe handlebars (triple curlybraces)

### DIFF
--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -135,7 +135,8 @@ def run_command(
         command,
         split=False,
         ignore_error=False,
-        include_errors=True):
+        include_errors=True,
+        shell=False):
     """
     Execute subprocesses.
     """
@@ -148,12 +149,15 @@ def run_command(
     else:
         error_pipe = subprocess.PIPE
 
+    if shell:
+        command = ' '.join(command)
+
     process = subprocess.Popen(
         command,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=error_pipe,
-        shell=False,
+        shell=shell,
         universal_newlines=True,
         env=env)
     if split:

--- a/lintreview/tools/unsafe_handlebars.py
+++ b/lintreview/tools/unsafe_handlebars.py
@@ -37,7 +37,11 @@ class UnsafeHandlebars(Tool):
             ignore_error=True, # no matches returns exit status of 1
             shell=True)
         for line in output:
-            filename, lineNumber, lineContents = re.search('^(.*?):([0-9]+):\s*(.*?)$', line).groups()
+            re_result = re.search('^(.*?):([0-9]+):\s*(.*?)$', line)
+            if re_result is None:
+                return
+
+            filename, lineNumber, lineContents = re_result.groups()
             lineNumber = int(lineNumber)
             message = """
 :warning: Warning! Potential XSS vulnerability. Are you sure you intended to use 3 curlybraces?

--- a/lintreview/tools/unsafe_handlebars.py
+++ b/lintreview/tools/unsafe_handlebars.py
@@ -1,0 +1,57 @@
+import logging
+import os
+import re
+from lintreview.tools import Tool
+from lintreview.tools import run_command
+from lintreview.utils import in_path
+from lintreview.utils import npm_exists
+
+log = logging.getLogger(__name__)
+
+
+class UnsafeHandlebars(Tool):
+
+    name = 'unsafe-handlebars'
+
+    def check_dependencies(self):
+        """
+        See if grep is on the system path.
+        """
+        return in_path('grep') or npm_exists('grep')
+
+    def match_file(self, filename):
+        base = os.path.basename(filename)
+        name, ext = os.path.splitext(base)
+        # Some .js can hand-compile handlebar templates
+        return ext == '.js' or ext == '.hbs'
+
+    def process_files(self, files):
+        """
+        grep the files for any unsafe variables (using three curly-braces)
+        """
+        log.debug('Processing %s files with %s', files, self.name)
+        command = self.create_command(files)
+        output = run_command(
+            command,
+            split=True,
+            ignore_error=True, # no matches returns exit status of 1
+            shell=True)
+        for line in output:
+            filename, lineNumber, lineContents = re.search('^(.*?):([0-9]+):\s*(.*?)$', line).groups()
+            lineNumber = int(lineNumber)
+            message = """
+:warning: Warning! Potential XSS vulnerability. Are you sure you intended to use 3 curlybraces?
+
+```
+%s
+```
+""" % lineContents
+            self.problems.add(filename, lineNumber, message)
+
+    def create_command(self, files):
+        cmd = 'grep'
+        if npm_exists('grep'):
+            cmd = os.path.join(os.getcwd(), 'node_modules', '.bin', 'grep')
+        command = [cmd, '-nR', '"{{{~\\?[A-Za-z.]\\+~\\?}}}"']
+        command += files
+        return command

--- a/tests/fixtures/unsafe_handlebars/has_errors.hbs
+++ b/tests/fixtures/unsafe_handlebars/has_errors.hbs
@@ -1,0 +1,14 @@
+<h1>Welcome {{name}}</h1>
+<p>Thanks for submitting your question, here it is:</p>
+<pre>
+  {{{query}}}
+</pre>
+
+<p>It's {{{meta.words}}} long. That's about a {{{meta.minutesToRead}}} minute read.</p>
+
+<div style="display:inline-block;">
+  {{{~ranOutOfIdeas~}}}
+  {{{ranOutOfIdeas~}}}
+  {{{~ranOutOfIdeas}}}
+  {{{~ran.out.ofIdeas~}}}
+</div>

--- a/tests/fixtures/unsafe_handlebars/no_errors.hbs
+++ b/tests/fixtures/unsafe_handlebars/no_errors.hbs
@@ -1,0 +1,17 @@
+<h1>Welcome {{name}}</h1>
+<p>This is a perfectly acceptable handlebar file</p>
+{{#if isTheBull}}
+  <p><strong>I see Justin Bull wishes to be immortalized in a shoddy fixture file</strong></p>
+{{else}}
+  <p>Well that's disappointing. Here's the weather:</p>
+  <ul>
+    {{#each day in weatherForecast}}
+      <li>{{day.day}}: {{day.temperature}}°C @ {{day.humidity}}% humidity</li>
+    {{/each}}
+  </ul>
+{{/if}}
+
+{{!-- Comment story bro --}}
+{{! Comment story bro }}
+
+Woot!

--- a/tests/tools/test_handlebars.py
+++ b/tests/tools/test_handlebars.py
@@ -1,0 +1,85 @@
+from lintreview.review import Problems
+from lintreview.review import Comment
+from lintreview.tools.unsafe_handlebars import UnsafeHandlebars
+from lintreview.utils import in_path
+from lintreview.utils import npm_exists
+from unittest import TestCase
+from unittest import skipIf
+from nose.tools import eq_
+
+grep_missing = not(in_path('grep') or npm_exists('grep'))
+
+
+class TestUnsafeHandlebars(TestCase):
+
+    needs_grep = skipIf(grep_missing, 'Needs grep to run')
+
+    fixtures = [
+        'tests/fixtures/unsafe_handlebars/no_errors.hbs',
+        'tests/fixtures/unsafe_handlebars/has_errors.hbs',
+    ]
+
+    def setUp(self):
+        self.problems = Problems()
+        self.tool = UnsafeHandlebars(self.problems)
+
+    def test_match_file(self):
+        self.assertFalse(self.tool.match_file('test.php'))
+        self.assertFalse(self.tool.match_file('dir/name/test.py'))
+        self.assertFalse(self.tool.match_file('test.py'))
+        self.assertTrue(self.tool.match_file('test.js'))
+        self.assertTrue(self.tool.match_file('dir/name/test.js'))
+        self.assertTrue(self.tool.match_file('test.hbs'))
+        self.assertTrue(self.tool.match_file('dir/name/test.hbs'))
+
+    @needs_grep
+    def test_check_dependencies(self):
+        self.assertTrue(self.tool.check_dependencies())
+
+    @needs_grep
+    def test_process_files__one_file_pass(self):
+        self.tool.process_files([self.fixtures[0]])
+        eq_([], self.problems.all(self.fixtures[0]))
+
+    @needs_grep
+    def test_process_files__multiple_error(self):
+        msg = """
+:warning: Warning! Potential XSS vulnerability. Are you sure you intended to use 3 curlybraces?
+
+```
+%s
+```
+"""
+        self.tool.process_files([self.fixtures[1]])
+        problems = self.problems.all(self.fixtures[1])
+        eq_(6, len(problems))
+
+        fname = self.fixtures[1]
+        expected = Comment(fname, 4, 4, msg % "{{{query}}}")
+        eq_(expected, problems[0])
+
+        expected = Comment(fname, 7, 7, msg % "<p>It's {{{meta.words}}} long. That's about a {{{meta.minutesToRead}}} minute read.</p>")
+        eq_(expected, problems[1])
+
+        expected = Comment(fname, 10, 10, msg % "{{{~ranOutOfIdeas~}}}")
+        eq_(expected, problems[2])
+
+    @needs_grep
+    def test_process_files_two_files(self):
+        self.tool.process_files(self.fixtures)
+
+        eq_([], self.problems.all(self.fixtures[0]))
+
+        problems = self.problems.all(self.fixtures[1])
+        eq_(6, len(problems))
+
+    def test_create_command__with_path_based_standard(self):
+        tool = UnsafeHandlebars(self.problems, None, '/some/path')
+        result = tool.create_command(['some/file.hbs'])
+        expected = [
+            '-nR',
+            '"{{{~\?[A-Za-z.]\+~\?}}}"',
+            'some/file.hbs'
+        ]
+        assert 'grep' in result[0], 'grep is in command name'
+        eq_(result[1:], expected)


### PR DESCRIPTION
I haven't had a chance to run the code, just test it.

Not sure if that comment body is sufficient, please let me know if I've stepped outside the bounds of the proper format.

Simply put, if you use `{{{fooBar}}}` anywhere in a `.hbs` or `.js` file, it'll make a comment to draw attention to it. There are rare cases you want this, but if it's a mistake this bot is supposed to catch it for you.

Unfortunately `shell=True` is required for any argument to popen that needs to use quotes. The grep's `"{{{~\\?[A-Za-z.]\\+~\\?}}}"` is the offender here.