### PR TITLE
Handle case where bundle isn't installed

### DIFF
--- a/lintreview/utils.py
+++ b/lintreview/utils.py
@@ -49,5 +49,8 @@ def bundle_exists(name):
 
     @return boolean
     """
-    installed = subprocess.check_output('bundle list')
+    try:
+        installed = subprocess.check_output('bundle list')
+    except OSError:
+        return False
     return name in installed


### PR DESCRIPTION
This chunk fails for us because we don't use bundle:
https://github.com/markstory/lint-review/blob/master/lintreview/tools/rubocop.py#L31-L33