### PR TITLE
Handle case where bundler exists, but there is no Gemfile

### DIFF
--- a/lintreview/utils.py
+++ b/lintreview/utils.py
@@ -51,6 +51,6 @@ def bundle_exists(name):
     """
     try:
         installed = subprocess.check_output(['bundle', 'list'])
-    except OSError:
+    except subprocess.CalledProcessError or OSError:
         return False
     return name in installed


### PR DESCRIPTION
```
adrian@kamek:~$ bundle list
Could not locate Gemfile
adrian@kamek:~$ echo $?
10
```