### PR TITLE
Docker build path bug

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,6 +1,7 @@
 # Lint Review
 
 [![Build Status](https://api.travis-ci.org/markstory/lint-review.svg)](https://travis-ci.org/markstory/lint-review)
+[![Docker Repository on Quay.io](https://quay.io/repository/freshbooks/lint-review/status "Docker Repository on Quay.io")](https://quay.io/repository/freshbooks/lint-review)
 
 Lint Review helps automate a tedious part of code review - enforcing coding
 standards. By using the github API Lint Review runs a repository's configured linters

--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest import skipIf
 from nose.tools import eq_
 
-phpcs_missing = not(composer_exists('phpcs') or in_path('phpcs'))
+phpcs_missing = not(composer_exists('phpcs'))
 
 
 class Testphpcs(TestCase):


### PR DESCRIPTION
Trying to fix the build error when building the docker container https://quay.io/repository/freshbooks/lint-review/build/3145d2a7-682d-4b53-8e94-f88e47280fbe

phpcs is in the path but not in `vendor/bin/phpcs`