### PR TITLE
Use the status API instead of comments for pass/fail

### DIFF
--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class Processor(object):
 
-    _client = None
+    _repository = None
     _number = None
     _head = None
     _target_path = None
@@ -19,13 +19,13 @@ class Processor(object):
     _review = None
     _config = None
 
-    def __init__(self, client, number, head, target_path, config=None):
-        self._client = client
+    def __init__(self, repository, number, head, target_path, config=None):
+        self._repository = repository
         self._number = number
         self._head = head
         self._target_path = target_path
         self._problems = Problems(target_path)
-        self._review = Review(client, number)
+        self._review = Review(repository, number)
 
         if config is None:
             config = {}
@@ -33,7 +33,7 @@ class Processor(object):
 
     def load_changes(self):
         log.info('Loading pull request patches from github.')
-        files = list(self._client.pull_request(self._number).files())
+        files = list(self._repository.pull_request(self._number).files())
         self._changes = DiffCollection(files)
         self._problems.set_changes(self._changes)
 
@@ -60,4 +60,4 @@ class Processor(object):
             self._config.get('SUMMARY_THRESHOLD'))
 
     def get_commits(self, number):
-	 return self._client.pull_request(number).commits()
+	 return self._repository.pull_request(number).commits()

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -60,4 +60,4 @@ class Processor(object):
             self._config.get('SUMMARY_THRESHOLD'))
 
     def get_commits(self, number):
-	 return self._repository.pull_request(number).commits()
+        return self._repository.pull_request(number).commits()

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -43,8 +43,6 @@ class IssueComment(object):
 
 class IssueLabel(object):
 
-    OK_LABEL = 'No lint errors'
-
     def __init__(self, label):
         self.label = label
 
@@ -195,31 +193,31 @@ class Review(object):
         Update the build status for the tip commit.
         The build will be a success if there are 0 problems.
         """
-        state = 'success'
-        description = 'No lint errors found.'
-        if problem_count > 0:
-            state = 'failure'
-            description = 'Lint errors found, see pull request comments.'
+        state = 'failure'
+        description = 'Lint errors found, see pull request comments.'
+        if problem_count == 0:
+            self.publish_ok_label()
+            self.publish_ok_comment()
+            state = 'success'
+            description = 'No lint errors found.'
         self._gh.create_status(
             self._pr.head.sha,
             state,
             None,
             description,
             'lintreview')
-        self.publish_ok_label()
-        self.publish_ok_comment()
 
     def remove_ok_label(self):
-        if config.get('ADD_OK_LABEL', False):
-            label = config.get('OK_LABEL', IssueLabel.OK_LABEL)
+        label = config.get('OK_LABEL', False)
+        if label:
             IssueLabel(label).remove(self._gh, self._number)
 
     def publish_ok_label(self):
         """
         Optionally publish the OK_LABEL if it is enabled.
         """
-        if config.get('ADD_OK_LABEL', False):
-            label = config.get('OK_LABEL', IssueLabel.OK_LABEL)
+        label = config.get('OK_LABEL', False)
+        if label:
             comment = IssueLabel(label)
             comment.publish(self._gh, self._number)
 

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -139,7 +139,6 @@ class Review(object):
         else:
             self.publish_summary(problems)
         self.publish_status(problem_count)
-        self.publish_ok_label()
 
     def load_comments(self):
         """
@@ -206,6 +205,8 @@ class Review(object):
             None,
             description,
             'lintreview')
+        self.publish_ok_label()
+        self.publish_ok_comment()
 
     def remove_ok_label(self):
         if config.get('ADD_OK_LABEL', False):
@@ -219,6 +220,15 @@ class Review(object):
         if config.get('ADD_OK_LABEL', False):
             label = config.get('OK_LABEL', IssueLabel.OK_LABEL)
             comment = IssueLabel(label)
+            comment.publish(self._gh, self._number)
+
+    def publish_ok_comment(self):
+        """
+        Optionally publish the OK_COMMENT if it is enabled.
+        """
+        comment = config.get('OK_COMMENT', False)
+        if comment:
+            comment = IssueComment(comment)
             comment.publish(self._gh, self._number)
 
     def publish_empty_comment(self):

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -68,7 +68,7 @@ class IssueLabel(object):
             if not gh.label(self.label):
                 gh.create_label(
                     name=self.label,
-                    color="bfe5bf", # a nice light green
+                    color="bfe5bf",  # a nice light green
                 )
             gh.issue(pull_request_number).add_labels(self.label)
         except:
@@ -93,7 +93,8 @@ class Comment(IssueComment):
         }
         log.debug("Publishing line comment '%s'", comment)
         try:
-            gh.pull_request(pull_request_number).create_review_comment(**comment)
+            gh.pull_request(pull_request_number) \
+                .create_review_comment(**comment)
         except:
             log.warn("Failed to save comment '%s'", comment)
 
@@ -329,6 +330,7 @@ class Problems(object):
         in the DiffCollection
         """
         changes = self._changes
+
         def sieve(err):
             if err.filename is None:
                 return True

--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -46,7 +46,6 @@ def process_pull_request(user, repo, number, lintrc):
                      target_branch)
             return
 
-
         # Clone/Update repository
         target_path = git.get_repo_path(user, repo, number, config)
         git.clone_or_update(config, head_repo, target_path, pr_head,

--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @celery.task(ignore_result=True)
-def process_pull_request(user, repo, number, target_branch, lintrc):
+def process_pull_request(user, repo, number, lintrc):
     """
     Starts processing a pull request and running the various
     lint tools against it.
@@ -29,20 +29,23 @@ def process_pull_request(user, repo, number, target_branch, lintrc):
         log.info('No configured linters, skipping processing.')
         return
 
-    if target_branch in review_config.ignore_branches():
-        log.info('Pull request into ignored branch %s, skipping processing.' %
-                 target_branch)
-        return
-
     try:
-        log.info('Loading pull request data from github. user=%s ' +
-                 'repo=%s number=%s target_branch=%s', user, repo,
-                 number, target_branch)
+        log.info('Loading pull request data from github. user=%s '
+                 'repo=%s number=%s', user, repo, number)
         gh = github.get_repository(config, user, repo)
         pull_request = gh.pull_request(number)
-        head_repo = pull_request.as_dict()['head']['repo']['clone_url']
-        private_repo = pull_request.as_dict()['head']['repo']['private']
-        pr_head = pull_request.as_dict()['head']['sha']
+
+        pr_dict = pull_request.as_dict()
+        head_repo = pr_dict['head']['repo']['clone_url']
+        private_repo = pr_dict['head']['repo']['private']
+        pr_head = pr_dict['head']['sha']
+
+        target_branch = pr_dict['base']['ref']
+        if target_branch in review_config.ignore_branches():
+            log.info('Pull request into ignored branch %s, skipping processing.' %
+                     target_branch)
+            return
+
 
         # Clone/Update repository
         target_path = git.get_repo_path(user, repo, number, config)

--- a/lintreview/tools/puppet.py
+++ b/lintreview/tools/puppet.py
@@ -32,7 +32,7 @@ class Puppet(Tool):
         if bundle_exists('puppet-lint'):
             command = ['bundle', 'exec', 'puppet-lint']
         command += ['--log-format',
-                   '%{path}:%{linenumber}:%{KIND}:%{message}']
+                    '%{path}:%{linenumber}:%{KIND}:%{message}']
         command += files
         output = run_command(
             command,

--- a/lintreview/web.py
+++ b/lintreview/web.py
@@ -35,7 +35,6 @@ def start_review():
         head_repo_url = pull_request["head"]["repo"]["git_url"]
         user = pull_request["base"]["repo"]["owner"]["login"]
         repo = pull_request["base"]["repo"]["name"]
-        target_branch = pull_request["base"]["ref"]
     except Exception as e:
         log.error("Got an invalid JSON body. '%s'", e)
         return Response(status=403,
@@ -63,7 +62,7 @@ def start_review():
         return Response(status=204)
     try:
         log.info("Scheduling pull request for %s/%s %s", user, repo, number)
-        process_pull_request.delay(user, repo, number, target_branch, lintrc)
+        process_pull_request.delay(user, repo, number, lintrc)
     except:
         log.error('Could not publish job to celery. Make sure its running.')
         return Response(status=500)

--- a/logging.ini
+++ b/logging.ini
@@ -2,7 +2,7 @@
 keys: simple
 
 [handlers]
-keys: console, file
+keys: console
 
 [loggers]
 keys: root

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -99,9 +99,7 @@ SUMMARY_THRESHOLD = env('LINTREVIEW_SUMMARY_THRESHOLD', 50, int)
 # OK_COMMENT = env('LINTREVIEW_OK_COMMENT',
 #                 ':+1: No lint errors found.')
 
-# Set to True to apply a label when updating build status.
+# Enable to apply a label when updating build status.
 # Pull requests that fail will have the label removed.
-# ADD_OK_LABEL = env('LINTREVIEW_ADD_OK_LABEL', False, bool)
-
 # Customize the label name when label statuses are enabled.
 # OK_LABEL = env('LINTREVIEW_OK_LABEL', 'No lint errors')

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -4,8 +4,8 @@ def env(key, default, cast=str):
     return cast(os.environ.get(key, default))
 
 
-# Webserver configuration #
-###########################
+# Webserver configuration
+#########################
 
 # gunicorn config
 bind = env('LINTREVIEW_GUNICORN_BIND', '127.0.0.1:5000')
@@ -25,8 +25,8 @@ SERVER_NAME = env('LINTREVIEW_SERVER_NAME', '127.0.0.1:5000')
 LOGGING_CONFIG = './logging.ini'
 
 
-# Celery worker configuration #
-###############################
+# Celery worker configuration
+#############################
 from kombu import Exchange, Queue
 
 # AMQP or other celery broker URL.
@@ -48,14 +48,21 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_ENABLE_UTC = True
 
 
-# General project configuration #
-#################################
+# General project configuration
+###############################
 
 # Path where project code should be
 # checked out when reviews are done
 # Repos will be checked out into $WORKSPACE/$user/$repo/$number
 # directories to prevent collisions.
 WORKSPACE = env('LINTREVIEW_WORKSPACE', '/tmp/workspace')
+
+# This config file contains default settings for .lintrc
+# LINTRC_DEFAULTS = './lintrc_defaults.ini'
+
+
+# Github Configuration
+######################
 
 # Use GITHUB_URL when working with github:e
 # When working with github:e don't forget to add the /api/v3/ path
@@ -84,10 +91,17 @@ SSL_CA_BUNDLE = None
 # prevent really noisy reviews from slowing down github.
 SUMMARY_THRESHOLD = env('LINTREVIEW_SUMMARY_THRESHOLD', 50, int)
 
-# This config file contains default settings for .lintrc
-# LINTRC_DEFAULTS = './lintrc_defaults.ini'
+# Status Configuration
+######################
 
-# Set to True to also apply a label when updating build statuses.
-# Cuts down on github notification noise.
-ADD_OK_LABEL = env('LINTREVIEW_ADD_OK_LABEL', False, bool)
-OK_LABEL = env('LINTREVIEW_OK_LABEL', 'No lint errors')
+# Uncomment this option to enable adding an issue comment
+# whenever a pull request passes all checks.
+# OK_COMMENT = env('LINTREVIEW_OK_COMMENT',
+#                 ':+1: No lint errors found.')
+
+# Set to True to apply a label when updating build status.
+# Pull requests that fail will have the label removed.
+# ADD_OK_LABEL = env('LINTREVIEW_ADD_OK_LABEL', False, bool)
+
+# Customize the label name when label statuses are enabled.
+# OK_LABEL = env('LINTREVIEW_OK_LABEL', 'No lint errors')

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -87,10 +87,7 @@ SUMMARY_THRESHOLD = env('LINTREVIEW_SUMMARY_THRESHOLD', 50, int)
 # This config file contains default settings for .lintrc
 # LINTRC_DEFAULTS = './lintrc_defaults.ini'
 
-OK_COMMENT = env('LINTREVIEW_OK_COMMENT',
-                 ':+1: No lint errors found.')
-
-# Set to True to use a label instead of a comment for OK status.
+# Set to True to also apply a label when updating build statuses.
 # Cuts down on github notification noise.
 ADD_OK_LABEL = env('LINTREVIEW_ADD_OK_LABEL', False, bool)
 OK_LABEL = env('LINTREVIEW_OK_LABEL', 'No lint errors')

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,5 +1,4 @@
 from . import load_fixture, create_pull_files
-from github3.pulls import PullFile
 from lintreview.diff import DiffCollection
 from lintreview.diff import Diff
 from unittest import TestCase

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,5 @@
 import lintreview.git as git
 import os
-import shutil
 from test_github import config
 from nose.tools import eq_
 from nose.tools import raises
@@ -34,6 +33,7 @@ def test_get_repo_path__int():
     expected = os.path.realpath(expected)
     eq_(res, expected)
 
+
 def test_get_repo_path__absoulte_dir():
     user = 'markstory'
     repo = 'asset_compress'
@@ -44,6 +44,7 @@ def test_get_repo_path__absoulte_dir():
         (settings['WORKSPACE'], user, repo, str(num)))
     expected = os.path.realpath(expected)
     eq_(res, expected)
+
 
 def test_exists__no_path():
     assert not git.exists(settings['WORKSPACE'] + '/herp/derp')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,7 @@
 import lintreview.github as github
 
 from . import load_fixture
-from mock import call, patch, Mock
+from mock import call, Mock
 from nose.tools import eq_
 import github3
 from github3 import GitHub
@@ -22,7 +22,7 @@ def test_get_client():
 
 def test_get_lintrc():
     repo = Mock(spec=github3.repos.repo.Repository)
-    lintrc = github.get_lintrc(repo)
+    github.get_lintrc(repo)
     repo.file_contents.assert_called_with('.lintrc')
 
 
@@ -51,8 +51,9 @@ def test_register_hook():
 def test_register_hook__already_exists():
     repo = Mock(spec=github3.repos.repo.Repository,
                 full_name='mark/lint-review')
-    repo.hooks.return_value = map(lambda f: github3.repos.hook.Hook(f),
-                                 json.loads(load_fixture('webhook_list.json')))
+    repo.hooks.return_value = map(
+        lambda f: github3.repos.hook.Hook(f),
+        json.loads(load_fixture('webhook_list.json')))
     url = 'http://example.com/review/start'
 
     github.register_hook(repo, url)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -4,9 +4,7 @@ from lintreview.diff import DiffCollection
 from github3.pulls import PullFile
 from mock import patch
 from mock import Mock
-from nose.tools import eq_
-from nose.tools import raises
-from requests.models import Response
+from nose.tools import eq_, raises
 from unittest import TestCase
 import json
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -120,7 +120,7 @@ class TestReview(TestCase):
     def test_publish_status__ok_no_comment_or_label(self):
         from lintreview.review import config
         review = Review(self.gh, 3)
-        mock_config = {'OK_COMMENT': None, 'ADD_OK_LABEL': None}
+        mock_config = {'OK_COMMENT': None, 'OK_LABEL': None}
         with patch.dict(config, mock_config):
             review.publish_status(0)
 
@@ -132,7 +132,7 @@ class TestReview(TestCase):
         from lintreview.review import config
         review = Review(self.gh, 3)
 
-        mock_config = {'OK_COMMENT': 'Great job!', 'ADD_OK_LABEL': True}
+        mock_config = {'OK_COMMENT': 'Great job!', 'OK_LABEL': 'No lint errors'}
         with patch.dict(config, mock_config):
             review.publish_status(0)
 
@@ -148,12 +148,12 @@ class TestReview(TestCase):
         self.issue.create_comment.assert_called_with('Great job!')
 
         assert self.issue.add_labels.called, 'Label added created'
-        self.issue.add_labels.assert_called_with(IssueLabel.OK_LABEL)
+        self.issue.add_labels.assert_called_with('No lint errors')
 
     def test_publish_status__has_errors(self):
         review = Review(self.gh, 3)
 
-        mock_config = {'OK_COMMENT': 'Great job!', 'ADD_OK_LABEL': True}
+        mock_config = {'OK_COMMENT': 'Great job!', 'OK_LABEL': 'No lint errors'}
         with patch.dict(config, mock_config):
             review.publish_status(1)
         assert self.gh.create_status.called, 'Create status not called'
@@ -179,7 +179,7 @@ class TestReview(TestCase):
         sha = 'abc123'
 
         review = Review(self.gh, 3)
-        label = IssueLabel.OK_LABEL
+        label = 'No lint errors'
 
         with add_ok_label(self.gh, 3, label):
             sha = 'abc123'
@@ -211,7 +211,7 @@ class TestReview(TestCase):
     def test_publish_empty_comment_add_ok_label(self):
         problems = Problems(changes=[])
         review = Review(self.gh, 3)
-        label = config.get('OK_LABEL', 'No lint errors')
+        label = 'No lint errors'
 
         with add_ok_label(self.gh, 3, label):
             sha = 'abc123'
@@ -399,7 +399,7 @@ def add_ok_label(gh, pr_number, *labels, **kw):
                 self.name = name
         gh.issue().labels.return_value = [Label(n) for n in labels]
 
-    mock_config = {'ADD_OK_LABEL': True, 'OK_LABEL': IssueLabel.OK_LABEL}
+    mock_config = {'OK_LABEL': 'No lint errors'}
     with patch.dict(config, mock_config):
         yield
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -5,12 +5,11 @@ from lintreview.diff import DiffCollection
 from lintreview.review import Review
 from lintreview.review import Problems
 from lintreview.review import Comment
-from lintreview.review import IssueComment, IssueLabel
+from lintreview.review import IssueLabel
 from mock import patch, Mock, call
 from nose.tools import eq_
 from github3.issues.comment import IssueComment as GhIssueComment
 from github3.pulls import PullFile
-from requests.models import Response
 from unittest import TestCase
 import json
 
@@ -259,7 +258,6 @@ class TestReview(TestCase):
         )
         problems.add_many(errors)
         problems.set_changes([1])
-        sha = 'abc123'
 
         review = Review(self.gh, 3)
         review.publish_summary(problems)
@@ -400,8 +398,6 @@ def add_ok_label(gh, pr_number, *labels, **kw):
             def __init__(self, name):
                 self.name = name
         gh.issue().labels.return_value = [Label(n) for n in labels]
-
-    gh.label.return_value = False;
 
     mock_config = {'ADD_OK_LABEL': True, 'OK_LABEL': IssueLabel.OK_LABEL}
     with patch.dict(config, mock_config):


### PR DESCRIPTION
Use the build status API to indicate whether or not a review passed. This will make lintreview far less chatty when it is reviewing code.