### PR TITLE
 Extract ini file parsing into separate methods

### DIFF
--- a/lintreview/config.py
+++ b/lintreview/config.py
@@ -166,8 +166,5 @@ class ReviewConfig(object):
                 continue
             # Strip off tool_
             linter = section[5:]
-            tool_config = dict(parser.items(section))
-            # Replace config if its missing or new config has data.
-            if linter not in data['linters'] or len(tool_config.keys()):
-                data['linters'][linter] = tool_config
+            data['linters'][linter] = dict(parser.items(section))
         self.update(data)

--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -3,8 +3,7 @@ import lintreview.git as git
 import logging
 
 from celery import Celery
-from lintreview.config import load_config, get_lintrc_defaults
-from lintreview.config import ReviewConfig
+from lintreview.config import load_config, build_review_config
 from lintreview.processor import Processor
 
 config = load_config()
@@ -22,8 +21,7 @@ def process_pull_request(user, repo, number, lintrc):
     """
     log.info('Starting to process lint for %s/%s/%s', user, repo, number)
     log.debug("lintrc contents '%s'", lintrc)
-    lintrc_defaults = get_lintrc_defaults(config)
-    review_config = ReviewConfig(lintrc, lintrc_defaults)
+    review_config = build_review_config(lintrc, config)
 
     if len(review_config.linters()) == 0:
         log.info('No configured linters, skipping processing.')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,27 +57,23 @@ def test_build_review_config():
 class ReviewConfigTest(TestCase):
 
     def test_linter_listing_bad(self):
-        config = ReviewConfig()
-        config.load_ini(bad_ini)
+        config = build_review_config(bad_ini)
         res = config.linters()
         eq_(res, [])
 
     def test_linter_listing(self):
-        config = ReviewConfig()
-        config.load_ini(sample_ini)
+        config = build_review_config(sample_ini)
         res = config.linters()
         expected = ['phpcs', 'pep8', 'jshint']
         eq_(sorted(res), sorted(expected))
 
     def test_linter_config_bad(self):
-        config = ReviewConfig()
-        config.load_ini(bad_ini)
+        config = build_review_config(bad_ini)
         res = config.linter_config('phpcs')
         eq_(res, [])
 
     def test_linter_config(self):
-        config = ReviewConfig()
-        config.load_ini(sample_ini)
+        config = build_review_config(sample_ini)
         res = config.linter_config('phpcs')
         expected = {
             'standard': 'test/CodeStandards',
@@ -89,8 +85,7 @@ class ReviewConfigTest(TestCase):
         eq_(res, [])
 
     def test_ignore_patterns(self):
-        config = ReviewConfig()
-        config.load_ini(sample_ini)
+        config = build_review_config(sample_ini)
         res = config.ignore_patterns()
         expected = ['test/CodeStandards/test/**', 'vendor/**']
         eq_(res, expected)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 
 from nose.tools import eq_
 
-from lintreview.config import load_config, get_lintrc_defaults
-from lintreview.config import ReviewConfig
+from lintreview.config import build_review_config, get_lintrc_defaults
+from lintreview.config import load_config, ReviewConfig
 
 sample_ini = """
 [files]
@@ -48,26 +48,36 @@ def test_get_lintrc_defaults():
     assert res is None
 
 
+def test_build_review_config():
+    config = build_review_config(sample_ini, {})
+    assert isinstance(config, ReviewConfig)
+    eq_(3, len(config.linters()))
+
+
 class ReviewConfigTest(TestCase):
 
     def test_linter_listing_bad(self):
-        config = ReviewConfig(bad_ini)
+        config = ReviewConfig()
+        config.load_ini(bad_ini)
         res = config.linters()
         eq_(res, [])
 
     def test_linter_listing(self):
-        config = ReviewConfig(sample_ini)
+        config = ReviewConfig()
+        config.load_ini(sample_ini)
         res = config.linters()
         expected = ['phpcs', 'pep8', 'jshint']
-        eq_(res, expected)
+        eq_(sorted(res), sorted(expected))
 
     def test_linter_config_bad(self):
-        config = ReviewConfig(bad_ini)
+        config = ReviewConfig()
+        config.load_ini(bad_ini)
         res = config.linter_config('phpcs')
         eq_(res, [])
 
     def test_linter_config(self):
-        config = ReviewConfig(sample_ini)
+        config = ReviewConfig()
+        config.load_ini(sample_ini)
         res = config.linter_config('phpcs')
         expected = {
             'standard': 'test/CodeStandards',
@@ -79,26 +89,31 @@ class ReviewConfigTest(TestCase):
         eq_(res, [])
 
     def test_ignore_patterns(self):
-        config = ReviewConfig(sample_ini)
+        config = ReviewConfig()
+        config.load_ini(sample_ini)
         res = config.ignore_patterns()
         expected = ['test/CodeStandards/test/**', 'vendor/**']
         eq_(res, expected)
 
     def test_ignore_patterns_missing(self):
-        config = ReviewConfig("")
+        config = ReviewConfig()
         res = config.ignore_patterns()
         eq_(res, [])
 
-    def test_default_settings_overridden(self):
-        config = ReviewConfig(sample_ini, defaults_ini)
+    def test_load_ini__override(self):
+        config = ReviewConfig()
+        config.load_ini(defaults_ini)
+        config.load_ini(sample_ini)
         res = config.linter_config('jshint')
         expected = {
             'config': './jshint.json',
         }
         eq_(res, expected)
 
-    def test_default_settings(self):
-        config = ReviewConfig(simple_ini, defaults_ini)
+    def test_load_ini__multiple_merges_settings(self):
+        config = ReviewConfig()
+        config.load_ini(defaults_ini)
+        config.load_ini(simple_ini)
         res = config.linter_config('jshint')
         expected = {
             'config': '/etc/jshint.json',

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1,6 +1,6 @@
 import lintreview.tools as tools
 import github3
-from lintreview.config import ReviewConfig
+from lintreview.config import ReviewConfig, build_review_config
 from lintreview.review import Review
 from lintreview.review import Problems
 from nose.tools import eq_, raises
@@ -31,13 +31,15 @@ linters = not there, bogus
 @raises(ImportError)
 def test_factory_raises_error_on_bad_linter():
     gh = Mock(spec=github3.GitHub)
-    config = ReviewConfig(bad_ini)
+    config = build_review_config(bad_ini)
+    config = ReviewConfig()
+    config.load_ini(bad_ini)
     tools.factory(Review(gh, None), config, '')
 
 
 def test_factory_generates_tools():
     gh = Mock(spec=github3.GitHub)
-    config = ReviewConfig(sample_ini)
+    config = build_review_config(sample_ini)
     linters = tools.factory(Review(gh, None), config, '')
     eq_(2, len(linters))
     assert isinstance(linters[0], tools.pep8.Pep8)
@@ -45,7 +47,7 @@ def test_factory_generates_tools():
 
 
 def test_run():
-    config = ReviewConfig(simple_ini)
+    config = build_review_config(simple_ini)
     problems = Problems()
     files = ['./tests/fixtures/pep8/has_errors.py']
     tools.run(config, problems, files, [], '')
@@ -53,7 +55,7 @@ def test_run():
 
 
 def test_run__filter_files():
-    config = ReviewConfig(simple_ini)
+    config = build_review_config(simple_ini)
     problems = Problems()
     files = [
         './tests/fixtures/pep8/has_errors.py',


### PR DESCRIPTION
Pre-parse the entire ini file and make ini parsing separate from the ReviewConfig constructor. Doing this will allow alternate configuration file formats to be integrated more easily in the future. For example adding yml configuration would be possible now.