### PR TITLE
Allow the status change to be turned off

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -197,10 +197,13 @@ class Review(object):
             self.publish_ok_comment()
             state = 'success'
             description = 'No lint errors found.'
-        self._repo.create_status(
-            self._pr.head,
-            state,
-            description)
+        status = self.config.get('PULLREQUEST_STATUS', True)
+        if status:
+            self._repo.create_status(
+                self._pr.head,
+                state,
+                description
+            )
 
     def remove_ok_label(self):
         label = self.config.get('OK_LABEL', False)

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -95,6 +95,9 @@ SUMMARY_THRESHOLD = env('LINTREVIEW_SUMMARY_THRESHOLD', 50, int)
 # Customize the build status integration name. Defaults to lintreview.
 # APP_NAME = 'lintreview'
 
+# Publish result to a pull requests status
+PULLREQUEST_STATUS = env('LINTREVIEW_PULLREQUEST_STATUS', True, bool)
+
 # Uncomment this option to enable adding an issue comment
 # whenever a pull request passes all checks.
 # OK_COMMENT = env('LINTREVIEW_OK_COMMENT',

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -111,17 +111,25 @@ class TestReview(TestCase):
             errors,
             sha)
 
-    def test_publish_status__ok_no_comment_or_label(self):
-        config = {'OK_COMMENT': None, 'OK_LABEL': None}
+    def test_publish_status__ok_no_comment_label_or_status(self):
+        config = {
+            'OK_COMMENT': None,
+            'OK_LABEL': None,
+            'PULLREQUEST_STATUS': False,
+        }
         review = Review(self.repo, self.pr, config)
         review.publish_status(0)
 
-        assert self.repo.create_status.called, 'Create status not called'
+        assert not self.repo.create_status.called, 'Create status called'
         assert not self.pr.create_comment.called, 'Comment not created'
         assert not self.pr.add_label.called, 'Label added created'
 
-    def test_publish_status__ok_with_comment_and_label(self):
-        config = {'OK_COMMENT': 'Great job!', 'OK_LABEL': 'No lint errors'}
+    def test_publish_status__ok_with_comment_label_and_status(self):
+        config = {
+            'OK_COMMENT': 'Great job!',
+            'OK_LABEL': 'No lint errors',
+            'PULLREQUEST_STATUS': True,
+        }
         review = Review(self.repo, self.pr, config)
         review.publish_status(0)
 


### PR DESCRIPTION
Some of our code bases are old and un-linted. Sometimes we ignore the linting
issue as it gets in the way of us doing actual changes, but it's still nice to
see the comments on a review.

If we were to use the latest version of lint-review, then we can't use the
branch protection feature from GitHub
(https://github.com/blog/2051-protected-branches-and-required-status-checks)

@markstory I know this goes against what you said in https://github.com/markstory/lint-review/pull/77#issuecomment-158836392, but having this feature on blocks us from using newer versions of lint-review. I figured having it on as a default made sense.