### PR TITLE
Fetch .lintrc from the HEAD branch

### DIFF
--- a/lintreview/github.py
+++ b/lintreview/github.py
@@ -26,7 +26,7 @@ def get_repository(config, user, repo):
     return gh.repository(owner=user, repository=repo)
 
 
-def get_lintrc(repo, ref=None):
+def get_lintrc(repo, ref):
     """
     Download the .lintrc from a repo
     """

--- a/lintreview/github.py
+++ b/lintreview/github.py
@@ -26,12 +26,12 @@ def get_repository(config, user, repo):
     return gh.repository(owner=user, repository=repo)
 
 
-def get_lintrc(repo):
+def get_lintrc(repo, ref=None):
     """
     Download the .lintrc from a repo
     """
     log.info('Fetching lintrc file')
-    response = repo.file_contents('.lintrc')
+    response = repo.file_contents('.lintrc', ref)
     return response.decoded
 
 

--- a/lintreview/web.py
+++ b/lintreview/web.py
@@ -33,8 +33,11 @@ def start_review():
         number = pull_request["number"]
         base_repo_url = pull_request["base"]["repo"]["git_url"]
         head_repo_url = pull_request["head"]["repo"]["git_url"]
+        head_repo_ref = pull_request["head"]["ref"]
         user = pull_request["base"]["repo"]["owner"]["login"]
+        head_user = pull_request["head"]["repo"]["owner"]["login"]
         repo = pull_request["base"]["repo"]["name"]
+        head_repo = pull_request["head"]["repo"]["name"]
     except Exception as e:
         log.error("Got an invalid JSON body. '%s'", e)
         return Response(status=403,
@@ -51,9 +54,9 @@ def start_review():
     if action == "closed":
         return close_review(user, repo, pull_request)
 
-    gh = get_repository(app.config, user, repo)
+    gh = get_repository(app.config, head_user, head_repo)
     try:
-        lintrc = get_lintrc(gh)
+        lintrc = get_lintrc(gh, head_repo_ref)
         log.debug("lintrc file contents '%s'", lintrc)
     except Exception as e:
         log.warn("Cannot download .lintrc file for '%s', "

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -22,8 +22,8 @@ def test_get_client():
 
 def test_get_lintrc():
     repo = Mock(spec=github3.repos.repo.Repository)
-    github.get_lintrc(repo)
-    repo.file_contents.assert_called_with('.lintrc')
+    github.get_lintrc(repo, 'HEAD')
+    repo.file_contents.assert_called_with('.lintrc', 'HEAD')
 
 
 def test_register_hook():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -9,8 +9,13 @@ test_data = {
     'pull_request': {
         'number': '3',
         'head': {
+            'ref': 'master',
             'repo': {
-                'git_url': 'testing',
+                'git_url': 'git://github.com/other/testing',
+                'name': 'testing',
+                'owner': {
+                    'login': 'other',
+                },
             },
         },
         'base': {


### PR DESCRIPTION
@markstory the `.lintrc` file was previously obtained from master on the base repo, meaning any changes wouldn't be taken into account until merged, or not at all if working on another branch than master.
The file is now fetched from the head fork and the corresponding branch, which means any change will be immediately used by lint-review. More enjoyable first-time use :smiley: 