### PR TITLE
Add support for upgraded ESLint

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -42,7 +42,7 @@ class IssueComment(object):
 
     def __repr__(self):
         return "%s(filename=%s, line=%s, position=%s, body=%s)" % (
-            str(self.__class__),
+            str(self.__class__.__name__),
             self.filename,
             self.line,
             self.position,

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -144,7 +144,7 @@ def run_command(
     """
     Execute subprocesses.
     """
-    log.debug('Running %s', ' '.join(command))
+    log.info('Running %s', ' '.join(command))
 
     env = os.environ.copy()
 

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -81,6 +81,9 @@ class Tool(object):
         Convert each of the files in `files` to an
         absolute path to locate the filename
         """
+        if name in files:
+            return name  # looks like it was already relative
+
         for f in files:
             abs_path = os.path.realpath(f)
             if abs_path == name:

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 from lintreview.tools import Tool
@@ -42,4 +43,7 @@ class Eslint(Tool):
         output = run_command(
             command,
             ignore_error=True)
-        self._process_checkstyle(output)
+        filename_converter = functools.partial(
+            self._relativize_filename,
+            files)
+        self._process_checkstyle(output, filename_converter)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "jscs": "1.13.x",
     "jshint": "2.6.x",
-    "eslint": "0.21.x",
+    "eslint": "2.4.x",
     "csslint": "0.10.x"
   }
 }

--- a/tests/fixtures/eslint/config.json
+++ b/tests/fixtures/eslint/config.json
@@ -1,5 +1,9 @@
 {
+    "extends": "eslint:recommended",
     "env": {
         "browser": true
+    },
+    "rules": {
+        "semi": ["error"]
     }
 }

--- a/tests/fixtures/eslint/has_errors.js
+++ b/tests/fixtures/eslint/has_errors.js
@@ -1,4 +1,4 @@
 // no semicolon, bar is not defined, foo is never used
 var foo = bar
-// alert is not defined
+// alert is only defined in the 'browser' environment
 alert("oh noes");

--- a/tests/fixtures/eslint/recommended_config.json
+++ b/tests/fixtures/eslint/recommended_config.json
@@ -1,0 +1,3 @@
+{
+    "extends": "eslint:recommended"
+}


### PR DESCRIPTION
It looks like the ESLint support was originally written for a pre 1.0 release.  The latest version is now 2.4.0.  The breaking changes are described here:
http://eslint.org/docs/user-guide/migrating-to-1.0.0
http://eslint.org/docs/user-guide/migrating-to-2.0.0

The biggest change is that all rules are off by default.  This means that tests depending on the default ruleset don't work.  That original behavior can be approximated by making a config which extends "eslint:recommended".
Also, it returns the absolute paths to filenames, so I added support for that.

This PR contains some other minor unrelated changes I made while getting acquainted with the codebase.  I'd be happy to break it up and PR things separately or drop them out of this PR as you see fit.

Do you typically handle multiple versions of linters?  I expect that this will still work with the older version of ESLint (due to the changes I made in `_relativize_filename`) but I haven't explicitly tested it.