### PR TITLE
Change this dict to an OrderedDict

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -339,7 +339,7 @@ class Problems(object):
                 return True
             return False
 
-        items = {}
+        items = OrderedDict()
         for error in self:
             if sieve(error):
                 items[error.key()] = error


### PR DESCRIPTION
Summary comments are unordered. I think this change was left out in
https://github.com/markstory/lint-review/commit/377512d8444ae8e73366d186bef370444b027772

When tracking down this problem and not being able to find it, @zoidbergwill managed to guess what it was:
![image](https://cloud.githubusercontent.com/assets/736329/14346827/4c847ad0-fcb4-11e5-9626-005841261af8.png)

Fixes https://github.com/markstory/lint-review/issues/88

