### PR TITLE
Override default user config in flake8 tests and minor "optimisation"

### DIFF
--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -15,11 +15,11 @@ class Flake8(Tool):
     PYFLAKE_OPTIONS = [
         'exclude',
         'filename',
-        'select',
-        'ignore',
-        'max-line-length',
         'format',
+        'ignore',
         'max-complexity',
+        'max-line-length',
+        'select',
         'snippet',
     ]
 

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -13,6 +13,7 @@ class Flake8(Tool):
 
     # see: http://flake8.readthedocs.org/en/latest/config.html
     PYFLAKE_OPTIONS = [
+        'config',
         'exclude',
         'filename',
         'format',

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -40,13 +40,14 @@ class Flake8(Tool):
         Only a single process is made for all files
         to save resources.
         """
-        log.debug('Processing %s files with %s', files, self.name)
+        log.debug('Processing %s files with %s', len(files), self.name)
         command = ['flake8']
-        for option in self.PYFLAKE_OPTIONS:
-            if self.options.get(option):
+        for option in self.options:
+            if option in self.PYFLAKE_OPTIONS:
                 command.extend(
-                    ['--%(option)s' % {'option': option},
-                     self.options.get(option)])
+                    ['--%s' % option, self.options.get(option)])
+            else:
+                log.warning('Set non-existent flake8 option: %s', option)
 
         command += files
         output = run_command(command, split=True, ignore_error=True)

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -14,7 +14,7 @@ class TestFlake8(TestCase):
 
     def setUp(self):
         self.problems = Problems()
-        self.tool = Flake8(self.problems)
+        self.tool = Flake8(self.problems, options={'config': ''})
 
     def test_match_file(self):
         self.assertFalse(self.tool.match_file('test.php'))
@@ -62,7 +62,8 @@ class TestFlake8(TestCase):
 
     def test_config_options_and_process_file(self):
         options = {
-            'ignore': 'F4,W603'
+            'ignore': 'F4,W603',
+            'config': ''
         }
         self.tool = Flake8(self.problems, options)
         self.tool.process_files([self.fixtures[1]])


### PR DESCRIPTION
I encountered a strange issue while trying to run tests, with an example below. I am ignoring `tests/*` in my person flake8 config, so when running the tests, it ignores `tests/*` files when running flake8, so my tests didn't pass successfully, so now in the tests I am over-riding the user config, in case someone is ignoring certain error codes or something.

```
13:52:12 [:~/src/git/python/lint-review] ± cat ~/.config/flake8
[flake8]
max-line-length = 160
exclude = tests/*
max-complexity = 10

13:51:53 [:~/src/git/python/lint-review] ± flake8 -v tests/fixtures/pep8/has_errors.py
user configuration: /Users/william/.config/flake8

13:51:55 [:~/src/git/python/lint-review/tests] ± flake8 -v fixtures/pep8/has_errors.py
user configuration: /Users/william/.config/flake8
checking fixtures/pep8/has_errors.py
fixtures/pep8/has_errors.py:2:1: F401 'os' imported but unused
fixtures/pep8/has_errors.py:2:1: F401 're' imported but unused
fixtures/pep8/has_errors.py:2:10: E401 multiple imports on one line
fixtures/pep8/has_errors.py:4:1: E302 expected 2 blank lines, found 1
fixtures/pep8/has_errors.py:6:6: E128 continuation line under-indented for visual indent
fixtures/pep8/has_errors.py:9:1: E302 expected 2 blank lines, found 1
fixtures/pep8/has_errors.py:10:11: E225 missing whitespace around operator
fixtures/pep8/has_errors.py:11:15: W603 '<>' is deprecated, use '!='
```