### PR TITLE
Add hashicorp packer configuration for AMI creation

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -1,2 +1,2 @@
 [tools]
-linters = flake8
+linters = flake8, jsonlint, yamllint

--- a/README.mdown
+++ b/README.mdown
@@ -53,6 +53,17 @@ php composer.phar install
 
 Once the dependencies are installed you should configure the repositories you want to review.
 
+## Using AWS
+
+To use aws, you can use [packer](http://packer.io) to generate an Amazon Machine Image to run the application
+
+Once you have your AWS credentials loaded you can run
+
+`packer build packer.json`
+
+Which will generate an AMI with the application and lint checkers installed.
+This can then be configured using cloud-init by writing the configuration to /etc/environment
+
 ## Using Docker
 
 To use docker, you'll need to install both docker, docker-compose and possibly docker toolbox

--- a/packer.json
+++ b/packer.json
@@ -1,0 +1,105 @@
+{
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-east-1",
+      "source_ami": "ami-840910ee",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "lint-review-{{timestamp}}",
+      "tags": {
+        "Name": "lint-review-{{timestamp}}",
+        "OS": "ubuntu"
+      },
+      "ami_description": "Lint review ami created {{timestamp}}",
+      "associate_public_ip_address": true,
+      "run_tags": {
+        "Name": "Packer Lint Review AMI builder"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "package.json",
+      "destination": "/home/ubuntu/package.json"
+    },
+    {
+      "type": "file",
+      "source": "requirements.txt",
+      "destination": "/home/ubuntu/requirements.txt"
+    },
+    {
+      "type": "file",
+      "source": "composer.json",
+      "destination": "/home/ubuntu/composer.json"
+    },
+    {
+      "type": "file",
+      "source": "composer.lock",
+      "destination": "/home/ubuntu/composer.lock"
+    },
+    {
+      "type": "file",
+      "source": "Gemfile",
+      "destination": "/home/ubuntu/Gemfile"
+    },
+    {
+      "type": "file",
+      "source": "Gemfile.lock",
+      "destination": "/home/ubuntu/Gemfile.lock"
+    },
+    {
+      "type": "file",
+      "source": "systemd/celery.service",
+      "destination": "/home/ubuntu/celery.service"
+    },
+    {
+      "type": "file",
+      "source": "systemd/gunicorn.service",
+      "destination": "/home/ubuntu/gunicorn.service"
+    },
+    {
+      "type": "file",
+      "source": "settings.sample.py",
+      "destination": "settings.py"
+    },
+    {
+      "type": "file",
+      "source": "logging.ini",
+      "destination": "logging.ini"
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo -E sh -e '{{ .Path }}'",
+      "inline": [
+        "DEBIAN_FRONTEND=noninteractive apt-get update",
+        "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y",
+        "DEBIAN_FRONTEND=noninteractive apt-get update",
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y rabbitmq-server",
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y python2.7 python-pip libffi-dev",
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y php7.0-cli php7.0-xml composer",
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y ruby2.3-dev",
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y npm",
+        "pip2 install lintreview",
+        "npm set progress=false",
+        "npm install -g",
+        "gem install bundler",
+        "echo '127.0.0.1 broker' > /etc/hosts",
+        "echo 'LINTREVIEW_GUNICORN_BIND=\"0.0.0.0:5000\"' >> /etc/environment",
+        "echo 'LINTREVIEW_SETTINGS=\"/home/ubuntu/settings.py\"' >> /etc/environment",
+        "mv gunicorn.service /lib/systemd/system/",
+        "systemctl enable gunicorn",
+        "mv celery.service /lib/systemd/system/",
+        "systemctl enable celery"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "bundle install --system",
+        "composer install"
+      ]
+    }
+  ]
+}

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -19,7 +19,8 @@ loglevel = env('LINTREVIEW_GUNICORN_LOGLEVEL', 'debug')
 # Basic flask config
 DEBUG = env('LINTREVIEW_FLASK_DEBUG', True, bool)
 TESTING = env('LINTREVIEW_TESTING', True, bool)
-SERVER_NAME = env('LINTREVIEW_SERVER_NAME', '127.0.0.1:5000')
+if os.environ.get('LINTREVIEW_SERVER_NAME') is not None:
+    SERVER_NAME = env('LINTREVIEW_SERVER_NAME')
 
 # Config file for logging
 LOGGING_CONFIG = './logging.ini'
@@ -71,7 +72,8 @@ GITHUB_URL = env('GITHUB_URL', 'https://api.github.com/')
 # Set the GITHUB_PASSWORD environment variable first.
 # example: $ export GITHUB_PASSWORD=mygithubpassword
 GITHUB_USER = env('GITHUB_USERNAME', 'octocat')
-GITHUB_PASSWORD = env('GITHUB_PASSWORD', '')
+if os.environ.get('GITHUB_PASSWORD') is not None:
+    GITHUB_PASSWORD = env('GITHUB_PASSWORD')
 
 # You can also use an Oauth token for github, if you do
 # uncomment this line. Using a token will take precedence

--- a/systemd/celery.service
+++ b/systemd/celery.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Lint Review Worker
+After=rabbitmq.service
+
+[Service]
+EnvironmentFile=/etc/environment
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=240
+Type=simple
+ExecStart=/usr/local/bin/celery -A lintreview.tasks worker
+WorkingDirectory=/home/ubuntu
+User=ubuntu
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/gunicorn.service
+++ b/systemd/gunicorn.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Lint Review Web Service
+After=rabbitmq.service
+
+[Service]
+EnvironmentFile=/etc/environment
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=240
+Type=simple
+ExecStart=/usr/local/bin/gunicorn -c /home/ubuntu/settings.py lintreview.web:app
+WorkingDirectory=/home/ubuntu
+User=ubuntu
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Configuration updates:
Only set SERVER_NAME and GITHUB_PASSWORD if supplied
Default behaviour will now be to respond to all HTTP hosts and only use
password authentication for github is explicitly set

TODO:
- Add (terraform) provisioning example
- Cluster multiple instances together
