### PR TITLE
Grab the problem count before setting the status

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -124,17 +124,18 @@ class Review(object):
             return self.publish_empty_comment()
 
         self.load_comments()
+        total_problem_count = len(problems)
         self.remove_existing(problems)
 
-        problem_count = len(problems)
+        new_problem_count = len(problems)
         under_threshold = (summary_threshold is None or
-                           problem_count < summary_threshold)
+                           new_problem_count < summary_threshold)
 
         if under_threshold:
             self.publish_problems(problems, head_sha)
         else:
             self.publish_summary(problems)
-        self.publish_status(problem_count)
+        self.publish_status(total_problem_count)
 
     def load_comments(self):
         """


### PR DESCRIPTION
Without this change I could close then open an existing PR, and since no new
lint issues were added, I got a green tick on my commit status. (since problems was 0)