### PR TITLE
Bump flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Flask==0.10.1
 github3.py==1.0.0a4
 nose==1.2.1
-pep8==1.5.7
-flake8==2.2.2
+pep8==1.7.0
+flake8==2.5.4
 celery==3.1.23
 mock==1.0.1
 gunicorn==0.17.2


### PR DESCRIPTION
And its requirement: pep8

It looks like multiprocessing is turned on in 2.2.3, which may help speed up a flake8 run.