### PR TITLE
Add golint support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: python
 
 python: "2.7"
 
-env:
-  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
-
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install shellcheck golang
+  - sudo apt-get install golang
+  - sudo add-apt-repository debian-sid
+  - sudo apt-get -qq update
+  - sudo apt-get install shellcheck
 
 install:
   - pip install .
@@ -33,6 +33,9 @@ before_script:
 
   # Sample config file
   - cp settings.sample.py settings.py
+
+env:
+  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
 
 script:
   - nosetests --with-coverage --cover-package lintreview

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ language: python
 
 python: "2.7"
 
+addons:
+  apt:
+    sources:
+      - debian-sid    # Grab ShellCheck from the Debian repo
+    packages:
+      - shellcheck
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install golang
-  - sudo apt-get install shellcheck
 
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ install:
   - pip install coverage
 
 before_script:
+  # Install golint
+  - go version
+  - go get -u github.com/golang/lint/golint
+
   # install node and npm tools
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
@@ -24,10 +28,6 @@ before_script:
   - rvm install 2.0.0
   - rvm use 2.0.0
   - bundle install --path ./bundle
-
-  - export GOPATH="${TRAVIS_BUILD_DIR}/gocode"
-  # Install golint
-  - go get -u github.com/golang/lint/golint
 
   # Sample config file
   - cp settings.sample.py settings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,17 @@ language: python
 
 python: "2.7"
 
+env:
+  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install shellcheck golang
+
 install:
   - pip install .
   - pip install codecov
   - pip install coverage
-
-addons:
-  apt:
-    sources:
-      - debian-sid
-      - precise
-    packages:
-      - shellcheck
-      - golang
 
 before_script:
   # install node and npm tools
@@ -36,16 +34,11 @@ before_script:
   # Sample config file
   - cp settings.sample.py settings.py
 
-env:
-  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
-
 script:
   - nosetests --with-coverage --cover-package lintreview
 
 after_success:
   - codecov
-
-sudo: false
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,15 @@ addons:
       - debian-sid
     packages:
       - shellcheck
+      - golang
 
 before_script:
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 5
+  # install node and npm tools
+  - rm -rf ~/.nvm
+  - git clone https://github.com/creationix/nvm.git ~/.nvm
+  - (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`)
+  - source ~/.nvm/nvm.sh
+  - nvm install 5
   - npm install
 
   # Use ruby2
@@ -23,11 +29,15 @@ before_script:
   - rvm use 2.0.0
   - bundle install --path ./bundle
 
+  # Install golint
+  - go get -u github.com/golang/lint/golint
+
   # Sample config file
   - cp settings.sample.py settings.py
 
 env:
   - LINTREVIEW_SETTINGS="./settings.py"
+  - GOPATH="./gocode"
 
 script:
   - nosetests --with-coverage --cover-package lintreview

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@ language: python
 
 python: "2.7"
 
-addons:
-  apt:
-    sources:
-      - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-      - shellcheck
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install golang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 
+dist: 'trusty'
+
 python: "2.7"
+
+env:
+  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"
 
 before_install:
   - sudo apt-get -qq update
@@ -31,9 +36,6 @@ before_script:
 
   # Sample config file
   - cp settings.sample.py settings.py
-
-env:
-  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"
 
 script:
   - nosetests --with-coverage --cover-package lintreview

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - rvm use 2.0.0
   - bundle install --path ./bundle
 
+  - export GOPATH="${TRAVIS_BUILD_DIR}/gocode"
   # Install golint
   - go get -u github.com/golang/lint/golint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
   apt:
     sources:
       - debian-sid
+      - precise
     packages:
       - shellcheck
       - golang

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ before_script:
   - cp settings.sample.py settings.py
 
 env:
-  - LINTREVIEW_SETTINGS="./settings.py"
-  - GOPATH="./gocode"
+  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
 
 script:
   - nosetests --with-coverage --cover-package lintreview

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python: "2.7"
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install golang
-  - sudo add-apt-repository debian-sid
-  - sudo apt-get -qq update
   - sudo apt-get install shellcheck
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - cp settings.sample.py settings.py
 
 env:
-  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="./gocode"
+  - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"
 
 script:
   - nosetests --with-coverage --cover-package lintreview

--- a/README.mdown
+++ b/README.mdown
@@ -382,3 +382,13 @@ Uses [ansible-lint](https://github.com/willthames/ansible-lint) to lint Ansible 
 *Options*
 
 * `ignore` Set which ansible-lint error codes you wish to ignore.
+
+### Go lang
+
+#### Golint
+
+Uses [go-lint](https://github.com/golang/lint) to lint go code.
+
+*Options*
+
+* `min_confidence` Set the confidence level of a problem before it is reported.

--- a/lintreview/tools/golint.py
+++ b/lintreview/tools/golint.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import functools
+from lintreview.tools import Tool
+from lintreview.tools import run_command
+from lintreview.utils import in_path, go_bin_path
+
+log = logging.getLogger(__name__)
+
+
+def process_quickfix(problems, output, filename_converter):
+    """
+    Process vim quickfix style results.
+
+    Each element in `output` should be formatted like::
+
+        <filename>:<line>:<col>:[ ]<message>
+    """
+    for line in output:
+        parts = line.split(':', 3)
+        message = parts[-1].strip()
+        filename = filename_converter(parts[0])
+        problems.add(filename, int(parts[1]), message)
+
+
+class Golint(Tool):
+    """
+    Run golint on files. This may need to offer config options
+    to map packages -> dirs so we can run golint once per package.
+    """
+
+    name = 'golint'
+
+    def check_dependencies(self):
+        """
+        See if golint is on the system path.
+        """
+        return in_path('golint') or go_bin_path('golint')
+
+    def match_file(self, filename):
+        base = os.path.basename(filename)
+        name, ext = os.path.splitext(base)
+        return ext == '.go'
+
+    def process_files(self, files):
+        """
+        Run code checks with golint.
+        Only a single process is made for all files
+        to save resources.
+        """
+        command = self.create_command(files)
+        output = run_command(
+            command,
+            ignore_error=True,
+            split=True,
+            include_errors=False)
+        filename_converter = functools.partial(
+            self._relativize_filename,
+            files)
+        process_quickfix(self.problems, output, filename_converter)
+
+    def create_command(self, files):
+        command = ['golint']
+        if go_bin_path('golint'):
+            command = [go_bin_path('golint')]
+        if 'min_confidence' in self.options:
+            command += ['-min_confidence', self.options.get('min_confidence')]
+        command += files
+        return command

--- a/lintreview/utils.py
+++ b/lintreview/utils.py
@@ -1,5 +1,8 @@
 import os
 import subprocess
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def in_path(name):
@@ -37,6 +40,22 @@ def composer_exists(name):
     cwd = os.getcwd()
     path = os.path.join(cwd, 'vendor', 'bin', name)
     return os.path.exists(path)
+
+
+def go_bin_path(name):
+    """
+    Get the path to a go binary. Handles traversing the GOPATH
+
+    @return str
+    """
+    gopath = os.environ.get('GOPATH')
+    if not gopath:
+        log.warn('GOPATH is not defined in environment, cannot locate go tools')
+        return ''
+    for dirname in gopath.split(os.pathsep):
+        if os.path.exists(os.path.join(dirname, 'bin', name)):
+            return os.path.join(dirname, 'bin', name)
+    return ''
 
 
 def bundle_exists(name):

--- a/lintreview/utils.py
+++ b/lintreview/utils.py
@@ -50,7 +50,8 @@ def go_bin_path(name):
     """
     gopath = os.environ.get('GOPATH')
     if not gopath:
-        log.warn('GOPATH is not defined in environment, cannot locate go tools')
+        log.warn('GOPATH is not defined in environment, '
+                 'cannot locate go tools')
         return ''
     for dirname in gopath.split(os.pathsep):
         if os.path.exists(os.path.join(dirname, 'bin', name)):

--- a/tests/fixtures/golint/has_errors.go
+++ b/tests/fixtures/golint/has_errors.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"flag"
+	"os"
+)
+
+func () Foo() {}
+
+func f(x int) bool {
+    if x > 0 {
+        return true
+    } else {
+        fmt.Printf("negative number %d", x)
+    }
+    return false
+}

--- a/tests/fixtures/golint/no_errors.go
+++ b/tests/fixtures/golint/no_errors.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"flag"
+)
+
+func main() {
+	flag.Parse()
+
+	fmt.Printf("Hello %s", flag.Arg(0))
+}

--- a/tests/tools/test_golint.py
+++ b/tests/tools/test_golint.py
@@ -1,6 +1,6 @@
 from lintreview.review import Problems, Comment
 from lintreview.tools.golint import Golint
-from lintreview.utils import in_path, go_bin_path
+from lintreview.utils import go_bin_path
 from unittest import TestCase, skipIf
 from nose.tools import eq_
 from mock import patch
@@ -55,7 +55,8 @@ class Testphpcs(TestCase):
             fname,
             14,
             14,
-            "if block ends with a return statement, so drop this else and outdent its block")
+            "if block ends with a return statement, "
+            "so drop this else and outdent its block")
         eq_(expected, problems[1])
 
     @needs_golint
@@ -78,7 +79,8 @@ class Testphpcs(TestCase):
         tool.process_files([self.fixtures[1]])
 
         mock_command.assert_called_with(
-            [   go_bin_path('golint'),
+            [
+                go_bin_path('golint'),
                 '-min_confidence', '1.0',
                 self.fixtures[1]
             ],

--- a/tests/tools/test_golint.py
+++ b/tests/tools/test_golint.py
@@ -1,0 +1,87 @@
+from lintreview.review import Problems, Comment
+from lintreview.tools.golint import Golint
+from lintreview.utils import in_path, go_bin_path
+from unittest import TestCase, skipIf
+from nose.tools import eq_
+from mock import patch
+
+golint_missing = not(go_bin_path('golint'))
+
+
+class Testphpcs(TestCase):
+
+    needs_golint = skipIf(golint_missing, 'Needs phpcs')
+
+    fixtures = [
+        'tests/fixtures/golint/no_errors.go',
+        'tests/fixtures/golint/has_errors.go',
+    ]
+
+    def setUp(self):
+        self.problems = Problems()
+        self.tool = Golint(self.problems)
+
+    def test_match_file(self):
+        self.assertTrue(self.tool.match_file('test.go'))
+        self.assertTrue(self.tool.match_file('dir/name/test.go'))
+        self.assertFalse(self.tool.match_file('dir/name/test.py'))
+        self.assertFalse(self.tool.match_file('test.php'))
+        self.assertFalse(self.tool.match_file('test.golp'))
+
+    @needs_golint
+    def test_check_dependencies(self):
+        self.assertTrue(self.tool.check_dependencies())
+
+    @needs_golint
+    def test_process_files__one_file_pass(self):
+        self.tool.process_files([self.fixtures[0]])
+        eq_([], self.problems.all(self.fixtures[0]))
+
+    @needs_golint
+    def test_process_files__one_file_fail(self):
+        self.tool.process_files([self.fixtures[1]])
+        problems = self.problems.all(self.fixtures[1])
+        eq_(2, len(problems))
+
+        fname = self.fixtures[1]
+        expected = Comment(
+            fname,
+            9,
+            9,
+            'exported function Foo should have comment or be unexported')
+        eq_(expected, problems[0])
+
+        expected = Comment(
+            fname,
+            14,
+            14,
+            "if block ends with a return statement, so drop this else and outdent its block")
+        eq_(expected, problems[1])
+
+    @needs_golint
+    def test_process_files_two_files(self):
+        self.tool.process_files(self.fixtures)
+
+        eq_([], self.problems.all(self.fixtures[0]))
+
+        problems = self.problems.all(self.fixtures[1])
+        eq_(2, len(problems))
+
+    @needs_golint
+    @patch('lintreview.tools.golint.run_command')
+    def test_process_files_with_config(self, mock_command):
+        mock_command.return_value = []
+        config = {
+            'min_confidence': '1.0'
+        }
+        tool = Golint(self.problems, config)
+        tool.process_files([self.fixtures[1]])
+
+        mock_command.assert_called_with(
+            [   go_bin_path('golint'),
+                '-min_confidence', '1.0',
+                self.fixtures[1]
+            ],
+            ignore_error=True,
+            split=True,
+            include_errors=False)


### PR DESCRIPTION
Add support for golint as a linting tool. Running this tool will require `$GOPATH` to be set and `golint` to be installed on $PATH or $GOPATH.