### PR TITLE
Make golint resiliant to multi-package failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,9 @@ requirements = open('./requirements.txt', 'r')
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
-    description="""
-    Lint Review, an automated code review tool that integrates with github.
-    Integrates with the github API & a variety of code checking tools.
-    """,
+    description="Lint Review, an automated code review tool that "
+                "integrates with github. Integrates with the github API "
+                "& a variety of code checking tools.",
     author="Mark story",
     author_email="mark@mark-story.com",
     packages=find_packages(),

--- a/tests/fixtures/golint/http.go
+++ b/tests/fixtures/golint/http.go
@@ -1,0 +1,10 @@
+package http
+
+import (
+	"fmt"
+	"io"
+)
+
+func main() {
+	fmt.Printf("Hello World")
+}


### PR DESCRIPTION
 golint doesn't like to review multiple files if they are from different packages. For now we'll just report that error. In the future there could be a configuration option that lets you define:

package -> glob patterns

lookups. I'm not sure multi-package projects are common enough to warrant that right now though.