### PR TITLE
Re-run golint when package errors are hit

### DIFF
--- a/lintreview/tools/golint.py
+++ b/lintreview/tools/golint.py
@@ -57,6 +57,9 @@ class Golint(Tool):
             files)
         # Look for multi-package error message, and re-run tools
         if len(output) == 1 and 'is in package' in output[0]:
+            log.info('Re-running golint on individual files'
+                     'as diff contains files from multiple packages: %s',
+                     output[0])
             self.run_individual_files(files, filename_converter)
         else:
             process_quickfix(self.problems, output, filename_converter)

--- a/lintreview/tools/golint.py
+++ b/lintreview/tools/golint.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import functools
-from lintreview.review import IssueComment
 from lintreview.tools import Tool, run_command
 from lintreview.utils import in_path, go_bin_path
 
@@ -53,13 +52,13 @@ class Golint(Tool):
             command,
             ignore_error=True,
             split=True)
-        # Look for multi-package error message
+        filename_converter = functools.partial(
+            self._relativize_filename,
+            files)
+        # Look for multi-package error message, and re-run tools
         if len(output) == 1 and 'is in package' in output[0]:
-            self.add_review_issue(output[0], files)
+            self.run_individual_files(files, filename_converter)
         else:
-            filename_converter = functools.partial(
-                self._relativize_filename,
-                files)
             process_quickfix(self.problems, output, filename_converter)
 
     def create_command(self, files):
@@ -71,17 +70,13 @@ class Golint(Tool):
         command += files
         return command
 
-    def add_review_issue(self, output, files):
+    def run_individual_files(self, files, filename_converter):
         """
-        Add an issue comment when the diff contains files
-        from multiple packages.
-
-        In the future it might be good to have a map of packages
-        to glob patterns to allow multi-package projects to be reviewed
+        If we get an error from golint about different packages
+        we have to re-run golint on each file as figuring out package
+        relations is hard.
         """
-        filename = output.split(' ')[0]
-        relative = self._relativize_filename(files, filename)
-        message = u"Could not complete review - %s" % (
-            output.replace(filename, relative),
-        )
-        self.problems.add(IssueComment(message.strip()))
+        for filename in files:
+            command = self.create_command([filename])
+            output = run_command(command, ignore_error=True, split=True)
+            process_quickfix(self.problems, output, filename_converter)

--- a/tests/fixtures/golint/http.go
+++ b/tests/fixtures/golint/http.go
@@ -6,5 +6,10 @@ import (
 )
 
 func main() {
-	fmt.Printf("Hello World")
+	if true {
+		fmt.Printf("Hello World")
+		return true;
+	} else {
+		return false
+	}
 }

--- a/tests/tools/test_golint.py
+++ b/tests/tools/test_golint.py
@@ -71,12 +71,12 @@ class TestGolint(TestCase):
 
     @needs_golint
     def test_process_files_in_different_packages(self):
-        self.tool.process_files([self.fixtures[0], self.fixtures[2]])
+        self.tool.process_files([self.fixtures[1], self.fixtures[2]])
 
         problems = self.problems.all()
-        eq_(1, len(problems))
-        assert 'Could not complete review - tests/fixture' in problems[0].body
-        assert 'is in package' in problems[0].body
+        eq_(3, len(problems))
+        eq_(2, len(self.problems.all(self.fixtures[1])))
+        eq_(1, len(self.problems.all(self.fixtures[2])))
 
     @needs_golint
     @patch('lintreview.tools.golint.run_command')


### PR DESCRIPTION
When we hit an error that files in a diff are from different packages, re-run golint on individual files instead of the group. This allows us to collect errors file by file instead of not at all.