### PR TITLE
Run tests in Docker Cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM python:2.7
 ENV REFRESHED_AT 2016-05-21
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1655A0AB68576280 && \
+    echo 'deb http://deb.nodesource.com/node_6.x jessie main' > /etc/apt/sources.list.d/nodesource-jessie.list
+
 RUN apt-get update && apt-get install -y \
     php-pear \
     ruby \
-    npm \
+    nodejs \
     ruby1.9.1 \
     ruby-dev \
     shellcheck \
@@ -11,7 +15,6 @@ RUN apt-get update && apt-get install -y \
     apt-get -y autoremove && \
     apt-get -y clean  && \
     rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 WORKDIR /code
 RUN pear install PHP_CodeSniffer

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,4 @@
+---
+sut:
+  build: .
+  command: docker_tests.sh

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
 ---
 sut:
   build: .
-  command: docker_tests.sh
+  command: /code/docker_tests.sh

--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pip install -r requirements-dev.txt
+pip install codecov coverage
+
+nosetests --with-coverage --cover-package lintreview


### PR DESCRIPTION
This allows the Docker Cloud to do tests. 

@markstory if you go to https://cloud.docker.com, find the repo, click "Builds" -> "Configure automated builds" you can turn on autotest. 

I found that `standardjs` was breaking in Docker, due to nodejs being ancient.

More info about Docker Cloud tests here: https://docs.docker.com/docker-cloud/builds/automated-testing/#set-up-automated-test-files