### PR TITLE
Updates for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: '3'
 services:
   broker:
     image: rabbitmq:3-management-alpine
@@ -14,6 +14,11 @@ services:
       - -c
       - /code/settings.py
       - lintreview.web:app
+    healthcheck:
+      test: ["CMD", "/code/docker_healthcheck.sh", "web"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     environment: &lintreview_env
       LINTREVIEW_GUNICORN_BIND: '0.0.0.0:5000'
       LINTREVIEW_GUNICORN_LOG_ACCESS: '-'
@@ -34,6 +39,11 @@ services:
       - worker
       - -l
       - info
+    healthcheck:
+      test: ["CMD", "/code/docker_healthcheck.sh", "worker"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     environment:
       <<: *lintreview_env
       C_FORCE_ROOT: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,4 @@ services:
 
 networks:
   front-tier:
-    driver: bridge
   back-tier:
-    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   broker:
-    image: rabbitmq:3-management
+    image: rabbitmq:3-management-alpine
     ports:
       - "15672:15672"
     networks:

--- a/docker_healthcheck.sh
+++ b/docker_healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ "$1" == "web" ]; then
+  curl -f http://localhost:5000/ping
+fi
+
+if [ "$1" == "worker" ]; then
+  celery inspect ping -A lintreview.tasks -d "celery@$HOSTNAME"
+fi


### PR DESCRIPTION
- Adds healthchecks
- Use a smaller rabbitmq image
- Switch docker-compose version

A note about the healthchecks, if rabbitmq were to die, the healthchecks on the worker containers should fail, and cause them to restart. Not really ideal.