### PR TITLE
Escape backticks in shellcheck.

### DIFF
--- a/lintreview/tools/shellcheck.py
+++ b/lintreview/tools/shellcheck.py
@@ -1,8 +1,7 @@
 import logging
 import os
 import functools
-from lintreview.tools import Tool
-from lintreview.tools import run_command
+from lintreview.tools import Tool, run_command, process_checkstyle
 from lintreview.utils import in_path
 
 log = logging.getLogger(__name__)
@@ -36,7 +35,11 @@ class Shellcheck(Tool):
         filename_converter = functools.partial(
             self._relativize_filename,
             files)
-        self._process_checkstyle(output, filename_converter)
+        process_checkstyle(self.problems, output, filename_converter)
+        map(self.escape_backtick, self.problems)
+
+    def escape_backtick(self, problem):
+        problem.body = problem.body.replace('`', '\`')
 
     def create_command(self, files):
         command = ['shellcheck']

--- a/tests/fixtures/shellcheck/has_errors.sh
+++ b/tests/fixtures/shellcheck/has_errors.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 echo $a
+BASE=`basename "$0"`
 
 echo "thing" 2>&1 > /dev/null

--- a/tests/tools/test_checkstyle.py
+++ b/tests/tools/test_checkstyle.py
@@ -94,7 +94,6 @@ class TestCheckstyle(TestCase):
         problems = self.problems.all()
         eq_(1, len(problems))
         assert_in('Running `checkstyle` failed', problems[0].body)
-        assert_in('badness.xml', problems[0].body)
         assert_in('config file exists and is valid XML', problems[0].body)
 
     def test_create_command__with_path_based_standard(self):

--- a/tests/tools/test_shellcheck.py
+++ b/tests/tools/test_shellcheck.py
@@ -42,7 +42,7 @@ class Testshellcheck(TestCase):
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        eq_(3, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
@@ -55,11 +55,19 @@ class Testshellcheck(TestCase):
 
         expected = Comment(
             fname,
-            5,
-            5,
+            4,
+            4,
+            'BASE appears unused. Verify it or export it.\n'
+            'Use $(..) instead of legacy \`..\`.')
+        eq_(expected, problems[1])
+
+        expected = Comment(
+            fname,
+            6,
+            6,
             'The order of the 2>&1 and the redirect matters. The 2>&1 has to '
             'be last.')
-        eq_(expected, problems[1])
+        eq_(expected, problems[2])
 
     @needs_shellcheck
     def test_process_files_two_files(self):
@@ -68,7 +76,7 @@ class Testshellcheck(TestCase):
         eq_([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        eq_(3, len(problems))
 
     @needs_shellcheck
     def test_process_files_with_config(self):
@@ -81,4 +89,4 @@ class Testshellcheck(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(1, len(problems), 'Changing standards changes error counts')
+        eq_(2, len(problems), 'Changing standards changes error counts')


### PR DESCRIPTION
Backticks in this tool are corrections, not formatting.