### PR TITLE
Don't log warnings on renamed files.

### DIFF
--- a/lintreview/diff.py
+++ b/lintreview/diff.py
@@ -38,9 +38,13 @@ class DiffCollection(object):
         to have additions at all.
 
         - Removed files never need to be linted as they are dead.
+        - Renamed files don't need to be linted as they have no diff
         - Any other file with a `+` in it should be checked.
         """
-        if content.status == 'removed':
+        if content.status in ('removed', 'renamed'):
+            return False
+        if content.additions == 0 and content.deletions == 0 \
+                and content.changes == 0:
             return False
         if not hasattr(content, 'patch'):
             return False

--- a/tests/fixtures/diff_with_rename_and_blob.json
+++ b/tests/fixtures/diff_with_rename_and_blob.json
@@ -11,11 +11,12 @@
     "raw_url": "https://github.com/mark/asset_compress/blob/2f343f8e5627c8b61449c16f105b5ac4ecd71359/images/example.png"
   },
   {
-    "status": "added",
+    "status": "renamed",
     "changes": 0,
     "deletions": 0,
     "additions": 0,
     "filename": "Test/test_files/View/Parse/single.ctp",
+    "previous_filename": "Test/test_files/View/Parse/singel.ctp",
     "contents_url": "https://api.github.com/repos/markstory/asset_compress/contents/Test/test_files/View/Parse/single.ctp?ref=22f9eeb51f7757055ac20b326bd3eddad6f98a3b",
     "raw_url": "https://github.com/markstory/asset_compress/raw/22f9eeb51f7757055ac20b326bd3eddad6f98a3b/Test/test_files/View/Parse/single.ctp",
     "sha": "fd131c525929d2515b9b5f9e65c310e4ba183975",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,6 +2,7 @@ from . import load_fixture, create_pull_files
 from lintreview.diff import DiffCollection
 from lintreview.diff import Diff
 from unittest import TestCase
+from mock import patch
 from nose.tools import eq_
 
 
@@ -104,8 +105,16 @@ class TestDiffCollection(TestCase):
 
     def test_parsing_diffs__renamed_file_and_blob(self):
         changes = DiffCollection(self.renamed_files)
-        eq_(0, len(changes), 'Should be no files as a blob and a rename happened')
+        eq_(0,
+            len(changes),
+            'Should be no files as a blob and a rename happened')
         eq_([], changes.get_files())
+
+    @patch('lintreview.diff.log')
+    def test_parsing_diffs__renamed_file_and_blob_no_log(self, log):
+        DiffCollection(self.renamed_files)
+        eq_(False, log.warn.called)
+        eq_(False, log.error.called)
 
     def assert_instances(self, collection, count, clazz):
         """


### PR DESCRIPTION
Don't log warnings on files being renamed. Also tweak the checks up to hopefully work around warnings on new blob files.