### PR TITLE
Shellcheck shebang

### DIFF
--- a/lintreview/tools/shellcheck.py
+++ b/lintreview/tools/shellcheck.py
@@ -20,7 +20,7 @@ class Shellcheck(Tool):
     def match_file(self, filename):
         base = os.path.basename(filename)
         name, ext = os.path.splitext(base)
-        return ext == '.sh'
+        return ext in ('.sh', '.bash', '.ksh', '.zsh')
 
     def process_files(self, files):
         """

--- a/lintreview/tools/shellcheck.py
+++ b/lintreview/tools/shellcheck.py
@@ -23,10 +23,7 @@ class Shellcheck(Tool):
         if ext in ('.sh', '.bash', '.ksh', '.zsh'):
             return True
 
-        if not os.path.exists(filename):
-            return False
-
-        if not os.access(filename, os.X_OK):
+        if not os.path.exists(filename) or not os.access(filename, os.X_OK):
             return False
 
         # Check for a shebang in the first line.

--- a/lintreview/tools/shellcheck.py
+++ b/lintreview/tools/shellcheck.py
@@ -20,7 +20,24 @@ class Shellcheck(Tool):
     def match_file(self, filename):
         base = os.path.basename(filename)
         name, ext = os.path.splitext(base)
-        return ext in ('.sh', '.bash', '.ksh', '.zsh')
+        if ext in ('.sh', '.bash', '.ksh', '.zsh'):
+            return True
+
+        if not os.path.exists(filename):
+            return False
+
+        if not os.access(filename, os.X_OK):
+            return False
+
+        # Check for a shebang in the first line.
+        with open(filename, 'r') as f:
+            line = f.readline()
+            return line.startswith('#!') and (
+                'bash' in line or
+                'sh' in line or
+                'zsh' in line or
+                'ksh' in line
+            )
 
     def process_files(self, files):
         """

--- a/tests/fixtures/shellcheck/tool
+++ b/tests/fixtures/shellcheck/tool
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo $a
+echo "thing" 2>&1 > /dev/null
+
+# vim set:ft=bash

--- a/tests/tools/test_shellcheck.py
+++ b/tests/tools/test_shellcheck.py
@@ -1,3 +1,4 @@
+import os
 from lintreview.review import Problems
 from lintreview.review import Comment
 from lintreview.tools.shellcheck import Shellcheck
@@ -31,6 +32,10 @@ class Testshellcheck(TestCase):
         self.assertFalse(self.tool.match_file('dir/name/test.py'))
         self.assertFalse(self.tool.match_file('test.py'))
         self.assertFalse(self.tool.match_file('test.js'))
+
+    def test_match_file__executable(self):
+        res = self.tool.match_file('tests/fixtures/shellcheck/tool')
+        self.assertTrue(res)
 
     @needs_shellcheck
     def test_check_dependencies(self):

--- a/tests/tools/test_shellcheck.py
+++ b/tests/tools/test_shellcheck.py
@@ -1,4 +1,3 @@
-import os
 from lintreview.review import Problems
 from lintreview.review import Comment
 from lintreview.tools.shellcheck import Shellcheck

--- a/tests/tools/test_shellcheck.py
+++ b/tests/tools/test_shellcheck.py
@@ -23,6 +23,9 @@ class Testshellcheck(TestCase):
         self.tool = Shellcheck(self.problems)
 
     def test_match_file(self):
+        self.assertTrue(self.tool.match_file('test.bash'))
+        self.assertTrue(self.tool.match_file('test.zsh'))
+        self.assertTrue(self.tool.match_file('test.ksh'))
         self.assertTrue(self.tool.match_file('test.sh'))
         self.assertTrue(self.tool.match_file('dir/name/test.sh'))
         self.assertFalse(self.tool.match_file('dir/name/test.py'))

--- a/tests/tools/test_tslint.py
+++ b/tests/tools/test_tslint.py
@@ -47,13 +47,10 @@ class TestTslint(TestCase):
         problems = self.problems.all(FILE_WITH_ERRORS)
         eq_(3, len(problems))
 
-        msg = ("The key 'middle' is not sorted alphabetically")
-        expected = Comment(FILE_WITH_ERRORS, 11, 11, msg)
-        eq_(expected, problems[0])
-
-        msg = ("Spaces before function parens are disallowed")
+        msg = ("Shadowed name: 'range'\n"
+               "Spaces before function parens are disallowed")
         expected = Comment(FILE_WITH_ERRORS, 1, 1, msg)
-        eq_(expected, problems[1])
+        eq_(expected, problems[0])
 
     @needs_tslint
     def test_process_files__invalid_config(self):
@@ -87,17 +84,14 @@ class TestTslint(TestCase):
 
         problems = self.problems.all(FILE_WITH_ERRORS)
 
-        msg = "The key 'middle' is not sorted alphabetically"
-        expected = Comment(FILE_WITH_ERRORS, 11, 11, msg)
+        msg = ("Shadowed name: 'range'\n"
+               'Spaces before function parens are disallowed')
+        expected = Comment(FILE_WITH_ERRORS, 1, 1, msg)
         eq_(expected, problems[0])
 
-        msg = 'Spaces before function parens are disallowed'
-        expected = Comment(FILE_WITH_ERRORS, 1, 1, msg)
+        msg = "The key 'middle' is not sorted alphabetically"
+        expected = Comment(FILE_WITH_ERRORS, 11, 11, msg)
         eq_(expected, problems[1])
-
-        msg = 'Missing trailing comma'
-        expected = Comment(FILE_WITH_ERRORS, 12, 12, msg)
-        eq_(expected, problems[2])
 
     @needs_tslint
     def test_process_output__ancestor_directory(self):


### PR DESCRIPTION
Check the first line of scripts to see if they have a shebang pointing at an interpreter supported by shellcheck. The file also needs to be executable.