### PR TITLE
Support all command line options for pep8

### DIFF
--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -29,7 +29,7 @@ class Pep8(Tool):
         """
         log.debug('Processing %s files with %s', files, self.name)
         command = ['pep8', '-r']
-        for option, value in self.options:
+        for option, value in self.options.items():
             command += ' --{}={}'.format(option, value)
         command += files
         output = run_command(command, split=True, ignore_error=True)

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -38,7 +38,7 @@ class Pep8(Tool):
             if option in pep8_options:
                 command += u' --{}={}'.format(option, value)
             else:
-                log.error(u'%s is not a valid option to pep8', option)
+                log.error('%s is not a valid option to pep8', option)
         command += files
         output = run_command(command, split=True, ignore_error=True)
         if not output:

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -29,8 +29,8 @@ class Pep8(Tool):
         """
         log.debug('Processing %s files with %s', files, self.name)
         command = ['pep8', '-r']
-        if self.options.get('ignore'):
-            command += ['--ignore', self.options.get('ignore')]
+        for option, value in self.options:
+            command += ' --{}={}'.format(option, value)
         command += files
         output = run_command(command, split=True, ignore_error=True)
         if not output:

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -36,9 +36,9 @@ class Pep8(Tool):
         command = ['pep8', '-r']
         for option, value in self.options.items():
             if option in pep8_options:
-                command += ' --{}={}'.format(option, value)
+                command += u' --{}={}'.format(option, value)
             else:
-                log.error('%s is not a valid option to pep8', option)
+                log.error(u'%s is not a valid option to pep8', option)
         command += files
         output = run_command(command, split=True, ignore_error=True)
         if not output:

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -28,9 +28,17 @@ class Pep8(Tool):
         to save resources.
         """
         log.debug('Processing %s files with %s', files, self.name)
+        pep8_options = ['exclude',
+                        'filename',
+                        'select',
+                        'ignore',
+                        'max-line-length']
         command = ['pep8', '-r']
         for option, value in self.options.items():
-            command += ' --{}={}'.format(option, value)
+            if option in pep8_options:
+                command += ' --{}={}'.format(option, value)
+            else:
+                log.error('%s is not a valid option to pep8', option)
         command += files
         output = run_command(command, split=True, ignore_error=True)
         if not output:


### PR DESCRIPTION
I was trying to change the --max-line-length.  I'm not sure why this code was only written to support `ignore`.  I'm proposing a change that would support everything.  If you'd prefer, this could also be written to only support recognized options (eg: `ignore`, `max-line-length`, ...).