### PR TITLE
Only sniff for errors when we don't get a checkstyle file back.

### DIFF
--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -47,6 +47,15 @@ class Eslint(Tool):
         self._process_output(output, files)
 
     def _process_output(self, output, files):
+        if '<?xml' not in output:
+            return self._config_error(output)
+
+        filename_converter = functools.partial(
+            self._relativize_filename,
+            files)
+        process_checkstyle(self.problems, output, filename_converter)
+
+    def _config_error(self, output):
         if 'Cannot read config file' in output:
             msg = u'Your eslint config file is missing or invalid. ' \
                    u'Please ensure that `{}` exists and is valid.'
@@ -73,8 +82,3 @@ class Eslint(Tool):
                   '```\n' \
                   'The above plugin is not installed.'
             return self.problems.add(IssueComment(msg.format(line)))
-
-        filename_converter = functools.partial(
-            self._relativize_filename,
-            files)
-        process_checkstyle(self.problems, output, filename_converter)


### PR DESCRIPTION
When the output doesn't contain an XML prolog we can more safely assume
that eslint failed and can start the error sniffing.

This solves problems where lint rules can contain 'Cannot find module'.