### PR TITLE
Make apply_base assume files are relative to base_path

### DIFF
--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -111,14 +111,19 @@ class Tool(object):
 
     def apply_base(self, value):
         """
-        Used to convert config values into absolute paths. If `value`
-        does not have a os.sep it will be returned unaltered.
+        Used to convert config values into absolute paths.
+
+        If the tool has a base_path set, the value will be relative to
+        that base path. If the value traverses to an ancestor of the base_path
+        only the basename of value will be returned. This is to prevent
+        directory traversal outside of the basedir.
         """
-        if os.sep not in value:
-            return value
         if not self.base_path:
             return value
-        return os.path.join(self.base_path, value)
+        path = os.path.abspath(os.path.join(self.base_path, value))
+        if path.startswith(self.base_path):
+            return path
+        return os.path.basename(value)
 
     def __repr__(self):
         return '<%sTool config: %s>' % (self.name, self.options)

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1,10 +1,20 @@
 import lintreview.tools as tools
 import github3
+import os
 from lintreview.config import ReviewConfig, build_review_config
 from lintreview.review import Review
 from lintreview.review import Problems
 from nose.tools import eq_, raises
 from mock import Mock
+
+
+fixture_path = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        '..',
+        'fixtures'
+    )
+)
 
 
 sample_ini = """
@@ -60,6 +70,42 @@ def test_tool_constructor__config():
 
     tool = tools.Tool(problems, None)
     eq_(tool.options, {})
+
+
+def test_tool_apply_base__no_base():
+    problems = Problems()
+    tool = tools.Tool(problems, {})
+
+    result = tool.apply_base('comments_current.json')
+    eq_(result, 'comments_current.json')
+
+
+def test_tool_apply_base__with_base():
+    problems = Problems()
+    tool = tools.Tool(problems, {}, fixture_path)
+
+    result = tool.apply_base('comments_current.json')
+    eq_(result, fixture_path + '/comments_current.json')
+
+    result = tool.apply_base('./comments_current.json')
+    eq_(result, fixture_path + '/comments_current.json')
+
+    result = tool.apply_base('eslint/config.json')
+    eq_(result, fixture_path + '/eslint/config.json')
+
+    result = tool.apply_base('./eslint/config.json')
+    eq_(result, fixture_path + '/eslint/config.json')
+
+    result = tool.apply_base('../fixtures/eslint/config.json')
+    eq_(result, fixture_path + '/eslint/config.json')
+
+
+def test_tool_apply_base__with_base_no_traversal():
+    problems = Problems()
+    tool = tools.Tool(problems, {}, fixture_path)
+
+    result = tool.apply_base('../../../comments_current.json')
+    eq_(result, 'comments_current.json')
 
 
 def test_run():


### PR DESCRIPTION
This makes defining config files easier as people won't need to use `./` to indicate the base_path directory. Instead they can use bare filenames.