### PR TITLE
Basic py3k integration

### DIFF
--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -40,6 +40,7 @@ class Py3k(Tool):
             log.debug('No py3k errors found.')
             return False
 
+        output = [line for line in output if not line.startswith("*********")]
         process_quickfix(self.problems, output, lambda name: name)
 
     def make_command(self, files):

--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+import os
+import logging
+from lintreview.tools import Tool, run_command, process_quickfix
+from lintreview.utils import in_path
+
+log = logging.getLogger(__name__)
+
+
+class Py3k(Tool):
+    """
+    $ pylint --py3k is a special mode for porting to python 3 which
+    disables other pylint checkers.
+    see https://github.com/PyCQA/pylint/issues/761
+    """
+
+    name = 'py3k'
+
+    def check_dependencies(self):
+        """
+        See if pylint is on the PATH
+        """
+        return in_path('pylint')
+
+    def match_file(self, filename):
+        base = os.path.basename(filename)
+        name, ext = os.path.splitext(base)
+        return ext == '.py'
+
+    def process_files(self, files):
+        """
+        Run code checks with pylint --py3k.
+        Only a single process is made for all files
+        to save resources.
+        """
+        log.debug('Processing %s files with %s', files, self.name)
+        command = self.make_command(files)
+        output = run_command(command, split=True, ignore_error=True)
+        if not output:
+            log.debug('No py3k errors found.')
+            return False
+
+        process_quickfix(self.problems, output, lambda name: name)
+
+    def make_command(self, files):
+        msg_template = '{path}:{line}:{column}:{msg_id} {msg}'
+        command = ['pylint', '--py3k', '--reports=n', '--msg-template', msg_template]
+        for option in self.options:
+            log.warning('Set non-existent py3k option: %s', option)
+        command.extend(files)
+        return command

--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -44,7 +44,13 @@ class Py3k(Tool):
 
     def make_command(self, files):
         msg_template = '{path}:{line}:{column}:{msg_id} {msg}'
-        command = ['pylint', '--py3k', '--reports=n', '--msg-template', msg_template]
+        command = [
+            'pylint',
+            '--py3k',
+            '--reports=n',
+            '--msg-template',
+            msg_template,
+        ]
         for option in self.options:
             log.warning('Set non-existent py3k option: %s', option)
         command.extend(files)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flake8>=3.3.0,<3.4.0
 yamllint>=1.6.1,<1.7.0
 demjson>=2.2.3,<2.3.0
 ansible-lint>=3.4.11,<3.5.0
+pylint>=1.7.4

--- a/tests/fixtures/py3k/has_errors.py
+++ b/tests/fixtures/py3k/has_errors.py
@@ -1,0 +1,11 @@
+# no __future__ import
+
+
+def thing():
+    # old style print statement
+    print 'derp'
+
+
+def thing2():
+    # using range in a non-iterative context
+    return range(10)

--- a/tests/fixtures/py3k/no_errors.py
+++ b/tests/fixtures/py3k/no_errors.py
@@ -1,0 +1,8 @@
+# Sample python file with no python 3 errors.
+# used for testing the py3k.Tool
+from __future__ import print_function
+
+
+def does_something(thing):
+    print("hello")
+    return thing.buzz()

--- a/tests/tools/test_py3k.py
+++ b/tests/tools/test_py3k.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 
-from nose.tools import eq_, assert_in, assert_not_in
+from nose.tools import eq_
 
 from lintreview.review import Problems
 from lintreview.review import Comment

--- a/tests/tools/test_py3k.py
+++ b/tests/tools/test_py3k.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+from unittest import TestCase
+
+from nose.tools import eq_, assert_in, assert_not_in
+
+from lintreview.review import Problems
+from lintreview.review import Comment
+from lintreview.tools.py3k import Py3k
+
+
+class TestPy3k(TestCase):
+
+    class fixtures:
+        no_errors = 'tests/fixtures/py3k/no_errors.py'
+        has_errors = 'tests/fixtures/py3k/has_errors.py'
+
+    def setUp(self):
+        self.problems = Problems()
+        self.tool = Py3k(self.problems)
+
+    def test_match_file(self):
+        self.assertFalse(self.tool.match_file('test.php'))
+        self.assertFalse(self.tool.match_file('test.js'))
+        self.assertFalse(self.tool.match_file('dir/name/test.js'))
+        self.assertTrue(self.tool.match_file('test.py'))
+        self.assertTrue(self.tool.match_file('dir/name/test.py'))
+
+    def test_process_files__one_file_pass(self):
+        self.tool.process_files([self.fixtures.no_errors])
+        eq_([], self.problems.all(self.fixtures.no_errors))
+
+    def test_process_files__one_file_fail(self):
+        self.tool.process_files([self.fixtures.has_errors])
+        problems = self.problems.all(self.fixtures.has_errors)
+        eq_(2, len(problems))
+
+        fname = self.fixtures.has_errors
+        eq_([
+            Comment(fname, 6, 6, 'E1601 print statement used'),
+            Comment(fname, 11, 11,
+                    'W1638 range built-in referenced when not iterating')
+        ], problems)
+
+    def test_process_files_two_files(self):
+        self.tool.process_files([self.fixtures.no_errors,
+                                 self.fixtures.has_errors])
+
+        eq_([], self.problems.all(self.fixtures.no_errors))
+
+        problems = self.problems.all(self.fixtures.has_errors)
+        eq_(2, len(problems))
+
+        fname = self.fixtures.has_errors
+        eq_([
+            Comment(fname, 6, 6, 'E1601 print statement used'),
+            Comment(fname, 11, 11,
+                    'W1638 range built-in referenced when not iterating')
+        ], problems)


### PR DESCRIPTION
@millerdev and I just added basic support for pylint's --py3k mode.  This identifies python 2 code which isn't also python 3 compatible.