### PR TITLE
Start using the Review API

### DIFF
--- a/lintreview/repo.py
+++ b/lintreview/repo.py
@@ -124,5 +124,9 @@ class GithubPullRequest(object):
     def create_comment(self, body):
         self.pull.create_comment(body)
 
+    def create_review(self, review):
+        url = self.pull._build_url('reviews', base_url=self.pull._api)
+        self.pull._json(self.pull._post(url, data=review), 201)
+
     def create_review_comment(self, body, commit_id, path, position):
         self.pull.create_review_comment(body, commit_id, path, position)

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -330,7 +330,7 @@ class Problems(object):
         If position is not supplied the diff collection will be scanned
         and the line numbers diff offset will be fetched from there.
         """
-        if isinstance(filename, IssueComment):
+        if isinstance(filename, BaseComment):
             self._items[filename.key()] = filename
             return
 
@@ -355,7 +355,7 @@ class Problems(object):
         """Add multiple problems to the review.
         """
         for p in problems:
-            self.add(*p)
+            self.add(p)
 
     def limit_to_changes(self):
         """Limit the contained problems to only those changed

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -5,53 +5,6 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class IssueComment(object):
-    """
-    A simple comment that will be published as a
-    pull request/issue comment.
-    """
-    filename = None
-    # TODO remove line it is not really needed
-    line = 0
-    position = 0
-    body = None
-
-    def __init__(self, body=''):
-        self.body = body
-
-    def publish(self, repo, pull_request):
-        log.debug("Publishing issue comment '%s'", self.body)
-        try:
-            pull_request.create_comment(self.body)
-        except Exception as e:
-            log.warn("Failed to save comment. body='%s' error=%s",
-                     self.body,
-                     e.message)
-
-    def key(self):
-        return (self.filename, self.position)
-
-    def append_body(self, text):
-        if text not in self.body:
-            self.body += "\n" + text
-
-    def __eq__(self, other):
-        """
-        Overload eq to make testing much simpler.
-        """
-        return (self.filename == other.filename and
-                self.position == other.position and
-                self.body == other.body)
-
-    def __repr__(self):
-        return "%s(filename=%s, line=%s, position=%s, body=%s)" % (
-            str(self.__class__.__name__),
-            self.filename,
-            self.line,
-            self.position,
-            self.body)
-
-
 class IssueLabel(object):
 
     def __init__(self, label):
@@ -73,32 +26,91 @@ class IssueLabel(object):
             log.warn("Failed to add label '%s'", self.label)
 
 
-class Comment(IssueComment):
-    """A line comment on the pull request."""
+class BaseComment(object):
+    """Shared behavior across comment types
+    """
+    body = ''
+
+    def key(self):
+        """Define the identifying tuple for a comment.
+        This should be a tuple of the file/position of the comment.
+        """
+        raise NotImplementedError()
+
+    def __eq__(self, other):
+        return False
+
+    def append_body(self, text):
+        if text not in self.body:
+            self.body += "\n" + text
+
+
+class IssueComment(BaseComment):
+    """A simple comment that will be published as a
+    pull request/issue comment.
+    """
+    def __init__(self, body=''):
+        self.body = body
+
+    def key(self):
+        """IssueComments are unique based on their body
+        """
+        return (self.body, None)
+
+    def __eq__(self, other):
+        return self.body == other.body
+
+    def __repr__(self):
+        return u"{}(body={}".format(self.__class__.__name__,
+                                    self.body)
+
+
+class Comment(BaseComment):
+    """A line comment on the pull request.
+
+    The `line` attribute is populated when comments are built
+    from tool output.
+
+    The `line` attribute is then mapped into a `position` when
+    a comment is merged with diff data.
+    """
+    line = 0
+    position = 0
+    body = ''
+    filename = ''
 
     def __init__(self, filename='', line=0, position=0, body=''):
-        super(Comment, self).__init__(body)
+        self.body = body
         self.line = line
         self.filename = filename
         self.position = position
 
-    def publish(self, repo, pull_request):
-        comment = {
-            'commit_id': pull_request.head,
+    def payload(self):
+        return {
             'path': self.filename,
             'position': self.position,
             'body': self.body,
         }
-        log.debug("Publishing line comment '%s'", comment)
-        try:
-            pull_request.create_review_comment(**comment)
-        except:
-            log.warn("Failed to save comment '%s'", comment)
+
+    def key(self):
+        return (self.filename, self.position)
+
+    def __eq__(self, other):
+        return (self.filename == other.filename and
+                self.position == other.position and
+                self.body == other.body)
+
+    def __repr__(self):
+        return "%s(filename=%s, line=%s, position=%s, body=%s)" % (
+            str(self.__class__.__name__),
+            self.filename,
+            self.line,
+            self.position,
+            self.body)
 
 
 class Review(object):
-    """
-    Holds the comments from a review can
+    """Holds the comments from a review can
     add track problems logged and post new problems
     to github.
     """
@@ -114,8 +126,7 @@ class Review(object):
         return self._comments.all(filename)
 
     def publish(self, problems, head_sha, summary_threshold=None):
-        """
-        Publish the review.
+        """Publish the review.
 
         Existing comments are loaded, and compared
         to new problems. Once the new unique problems
@@ -136,14 +147,13 @@ class Review(object):
                            new_problem_count < summary_threshold)
 
         if under_threshold:
-            self.publish_problems(problems, head_sha)
+            self.publish_review(problems, head_sha)
         else:
             self.publish_summary(problems)
         self.publish_status(total_problem_count)
 
     def load_comments(self):
-        """
-        Load the existing comments on a pull request
+        """Load the existing comments on a pull request
 
         Results in a structure that is similar to the one used
         for problems
@@ -166,8 +176,7 @@ class Review(object):
         log.debug("'%s' comments loaded", len(self._comments))
 
     def remove_existing(self, problems):
-        """
-        Modifies the problems parameter removing
+        """Modifies the problems parameter removing
         problems that already have matching comments.
         Filters the problems based on existing comments.
 
@@ -178,22 +187,42 @@ class Review(object):
         for comment in self._comments:
             problems.remove(comment)
 
-    def publish_problems(self, problems, head_commit):
-        """
-        Publish the issues contains in the problems
+    def publish_review(self, problems, head_commit):
+        """Publish the issues contains in the problems
         parameter. changes is used to fetch the commit sha
         for the comments on a given file.
         """
-        log.info("Publishing (%s) new comments for %s",
+        log.info("Publishing review of %s new comments for %s",
                  len(problems),
                  self._pr.display_name)
         self.remove_ok_label()
-        for error in problems:
-            error.publish(self._repo, self._pr)
+        review = self._build_review(problems, head_commit)
+        self._pr.create_review(review)
+
+    def _build_review(self, problems, head_commit):
+        """Because github3.py doesn't support creating reviews
+        we use some workarounds
+        """
+        body = [
+            comment.body
+            for comment in problems
+            if isinstance(comment, IssueComment)
+        ]
+        comments = [
+            comment.payload()
+            for comment in problems
+            if isinstance(comment, Comment)
+        ]
+        review = {
+            'commit_id': head_commit,
+            'event': 'COMMENT',
+            'body': "\n\n".join(body),
+            'comments': comments
+        }
+        return review
 
     def publish_status(self, problem_count):
-        """
-        Update the build status for the tip commit.
+        """Update the build status for the tip commit.
         The build will be a success if there are 0 problems.
         """
         state = 'failure'
@@ -216,8 +245,7 @@ class Review(object):
             IssueLabel(label).remove(self._pr)
 
     def publish_ok_label(self):
-        """
-        Optionally publish the OK_LABEL if it is enabled.
+        """Optionally publish the OK_LABEL if it is enabled.
         """
         label = self.config.get('OK_LABEL', False)
         if label:
@@ -225,20 +253,17 @@ class Review(object):
             issue_label.publish(self._repo, self._pr)
 
     def publish_ok_comment(self):
-        """
-        Optionally publish the OK_COMMENT if it is enabled.
+        """Optionally publish the OK_COMMENT if it is enabled.
         """
         comment = self.config.get('OK_COMMENT', False)
         if comment:
-            comment = IssueComment(comment)
-            comment.publish(self._repo, self._pr)
+            self._pr.create_comment(comment)
 
     def publish_empty_comment(self):
         self.remove_ok_label()
         body = ('Could not review pull request. '
                 'It may be too large, or contain no reviewable changes.')
-        comment = IssueComment(body)
-        comment.publish(self._repo, self._pr)
+        self._pr.create_comment(body)
 
         if self.config.get('PULLREQUEST_STATUS', True):
             self._repo.create_status(
@@ -253,13 +278,11 @@ class Review(object):
         for problem in problems:
             body += "* {0.filename}, line {0.line} - {0.body}\n".format(
                 problem)
-        comment = IssueComment(body)
-        comment.publish(self._repo, self._pr)
+        self._pr.create_comment(body)
 
 
 class Problems(object):
-    """
-    Collection class for holding all the problems found
+    """Collection class for holding all the problems found
     during automated review.
 
     Used by tool objects to collect problems, and by
@@ -285,8 +308,7 @@ class Problems(object):
         return filename[len(self._base):]
 
     def line_to_position(self, filename, line):
-        """
-        Convert the line number in the final file to a diff offset
+        """Convert the line number in the final file to a diff offset
 
         Saving comments in github requires line offsets no line numbers.
         Mapping line numbers makes saving possible.
@@ -303,8 +325,7 @@ class Problems(object):
         return list(self._items.values())
 
     def add(self, filename, line=None, body=None, position=None):
-        """
-        Add a problem to the review.
+        """Add a problem to the review.
 
         If position is not supplied the diff collection will be scanned
         and the line numbers diff offset will be fetched from there.
@@ -331,21 +352,19 @@ class Problems(object):
             self._items[key].append_body(error.body)
 
     def add_many(self, problems):
-        """
-        Add multiple problems to the review.
+        """Add multiple problems to the review.
         """
         for p in problems:
             self.add(*p)
 
     def limit_to_changes(self):
-        """
-        Limit the contained problems to only those changed
+        """Limit the contained problems to only those changed
         in the DiffCollection
         """
         changes = self._changes
 
         def sieve(err):
-            if err.filename is None:
+            if not hasattr(err, 'filename'):
                 return True
             if changes.has_line_changed(err.filename, err.line):
                 return True
@@ -358,8 +377,7 @@ class Problems(object):
         self._items = items
 
     def remove(self, comment):
-        """
-        Remove a problem from the list based on the filename
+        """Remove a problem from the list based on the filename
         position and comment.
         """
         found = False

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -161,6 +161,24 @@ class TestGithubPullRequest(TestCase):
             comment['path'],
             comment['position'])
 
+    def test_create_review(self):
+        self.model._post = Mock()
+        self.model._json = Mock()
+        pull = GithubPullRequest(self.model)
+        review = {
+            'commit_id': 'abc123',
+            'event': 'COMMENT',
+            'body': 'Bad things',
+            'comments': [
+                {'position': 1, 'body': 'Bad space', 'path': 'some/file.php'}
+            ]
+        }
+        pull.create_review(review)
+        self.model._post.assert_called_with(
+            'https://api.github.com/repos/markstory/lint-test/pulls/1/reviews',
+            data=review)
+        assert self.model._json.called
+
 
 @contextmanager
 def add_ok_label(pull_request, *labels, **kw):

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -114,7 +114,7 @@ def test_run():
     problems = Problems()
     files = ['./tests/fixtures/pep8/has_errors.py']
     tools.run(config, problems, files, [], '')
-    eq_(6, len(problems))
+    eq_(7, len(problems))
 
 
 def test_run__filter_files():
@@ -125,4 +125,4 @@ def test_run__filter_files():
         './tests/fixtures/phpcs/has_errors.php'
     ]
     tools.run(config, problems, files, [], '')
-    eq_(6, len(problems))
+    eq_(7, len(problems))


### PR DESCRIPTION
Publish linter output with the reviews API instead of the comment APIs. This results in fewer email notifications to collaborators and reduces the API traffic that lintreview creates. It also allows reviews to be more atomic as GitHub should accept or reject an entire review.

I've done a bit of clean-up in the tests as well.