### PR TITLE
Add diff parsing

### DIFF
--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+git config --global user.name dockerbot
+git config --global user.email dockerbot@example.com
 
 pip install -r requirements-dev.txt
 pip install codecov coverage

--- a/lintreview/diff.py
+++ b/lintreview/diff.py
@@ -29,6 +29,10 @@ def parse_diff(text):
         if len(chunk) == 0:
             continue
         diffs.append(parse_file_diff(chunk))
+    if not diffs:
+        msg = u'Could not parse any diffs from provided diff text.'
+        raise ParseError(msg)
+
     return DiffCollection(diffs)
 
 
@@ -42,12 +46,20 @@ def parse_file_diff(chunk):
         if line.startswith('+++'):
             filename = line[6:]
             continue
+        if not filename:
+            continue
         patch.append(line)
+
+    if not patch:
+        msg = u'Could not parse diff for {}'.format(filename)
+        raise ParseError(msg)
+
     return DiffAdapter(
         patch='\n'.join(patch),
         filename=filename,
         sha=None,
         status='modified',
+        # Placeholder values to quack like github data.
         additions=1,
         deletions=1,
         changes=1)

--- a/lintreview/diff.py
+++ b/lintreview/diff.py
@@ -218,7 +218,7 @@ class Diff(object):
             if not line.startswith('-'):
                 line_num += 1
             if line.startswith('-'):
-                deletions.append(line_num)
+                deletions.append(line_num + 1)
             if line.startswith('+'):
                 additions.append(line_num)
                 line_map[line_num] = i

--- a/lintreview/diff.py
+++ b/lintreview/diff.py
@@ -3,8 +3,58 @@ import fnmatch
 import re
 import os
 import logging
+from collections import namedtuple
 
 log = logging.getLogger(__name__)
+
+# Adapter to make parsed text diffs quack like github API
+# responses.
+DiffAdapter = namedtuple(
+    'DiffAdapter',
+    ('patch', 'filename', 'sha', 'status',
+     'additions', 'deletions', 'changes')
+)
+
+
+def parse_diff(text):
+    """Parse the output of `git diff` into
+    a DiffCollection and set of diff objects
+    """
+    if not text:
+        raise ParseError('No diff provided')
+    file_pattern = r'diff \-\-git a/.* b/.*'
+    blocks = re.split(file_pattern, text)
+    diffs = []
+    for chunk in blocks:
+        if len(chunk) == 0:
+            continue
+        diffs.append(parse_file_diff(chunk))
+    return DiffCollection(diffs)
+
+
+def parse_file_diff(chunk):
+    filename = None
+    patch = []
+    for line in chunk.split('\n'):
+        # Ignore the - filename and index refspec
+        if line.startswith('---') or line.startswith('index'):
+            continue
+        if line.startswith('+++'):
+            filename = line[6:]
+            continue
+        patch.append(line)
+    return DiffAdapter(
+        patch='\n'.join(patch),
+        filename=filename,
+        sha=None,
+        status='modified',
+        additions=1,
+        deletions=1,
+        changes=1)
+
+
+class ParseError(RuntimeError):
+    pass
 
 
 class DiffCollection(object):
@@ -31,7 +81,9 @@ class DiffCollection(object):
         if not self._has_additions(content):
             log.debug('Skipping %s as it has no additions', content.filename)
             return
-        change = Diff(content)
+        change = Diff(content.patch,
+                      content.filename,
+                      content.sha)
         self._changes.append(change)
 
     def _has_additions(self, content):
@@ -118,22 +170,29 @@ class Diff(object):
     Github's API returns one Diff per file
     in a pull request.
     """
-    def __init__(self, data):
-        self._data = data
-        self._parse_diff(data.patch)
+    def __init__(self, patch, filename, sha):
+        self._filename = filename
+        self._sha = sha
+        self._patch = patch
+        self._parse_diff(patch)
 
     def _parse_diff(self, patch):
         """
         Parses the diff data and stores the list of
         line numbers that were added in this diff.
 
-        We don't care about deletions as they won't
-        have lint errors in them.
+        We track the 'new' version of the diff, and not the old
+        version as we care about the new state of the file when
+        applying linters. When applying fixers if an added/modified
+        line intersects with the previous change we also care.
         """
         hunk_pattern = re.compile('\@\@ \-\d+,\d+ \+(\d+),\d+ \@\@')
 
         line_num = 1
+
         additions = []
+        deletions = []
+
         line_map = {}
         lines = patch.split("\n")
         for i, line in enumerate(lines):
@@ -146,19 +205,26 @@ class Diff(object):
             # unchanged lines.
             if not line.startswith('-'):
                 line_num += 1
+            if line.startswith('-'):
+                deletions.append(line_num)
             if line.startswith('+'):
                 additions.append(line_num)
                 line_map[line_num] = i
         self._additions = set(additions)
+        self._deletions = set(deletions)
         self._indexes = line_map
 
     @property
     def filename(self):
-        return self._data.filename
+        return self._filename
+
+    @property
+    def patch(self):
+        return self._patch
 
     @property
     def commit(self):
-        return self._data.sha
+        return self._sha
 
     def has_line_changed(self, line):
         """
@@ -166,6 +232,14 @@ class Diff(object):
         diffs
         """
         return line in self._additions
+
+    def added_lines(self):
+        """Get the line numbers of lines that were added"""
+        return self._additions
+
+    def deleted_lines(self):
+        """Get the line numbers of lines that were deleted"""
+        return self._deletions
 
     def line_position(self, line_number):
         """

--- a/tests/fixtures/diff/one_file.txt
+++ b/tests/fixtures/diff/one_file.txt
@@ -1,14 +1,39 @@
-diff --git a/lintreview/diff.py b/lintreview/diff.py
-index 11ce912..1eff317 100644
---- a/lintreview/diff.py
-+++ b/lintreview/diff.py
-@@ -7,6 +7,14 @@ import logging
- log = logging.getLogger(__name__)
+diff --git a/tests/test_diff.py b/tests/test_diff.py
+index 1f65acd..caab2e0 100644
+--- a/tests/test_diff.py
++++ b/tests/test_diff.py
+@@ -3,12 +3,13 @@ from . import load_fixture, create_pull_files
+ from lintreview.diff import DiffCollection, Diff, parse_diff, ParseError
+ from unittest import TestCase
+ from mock import patch
+-from nose.tools import eq_, raises, assert_in, assert_not_in
++from nose.tools import eq_, assert_raises, assert_in, assert_not_in
 
 
-+def parse_diff(text):
-+    """Parse the output of `git diff` into
-+    a DiffCollection and set of diff objects
+-@raises(ParseError)
+ def test_parse_diff__no_input():
+-    parse_diff('')
++    with assert_raises(ParseError) as ctx:
++        parse_diff('')
++    assert_in('No diff', str(ctx.exception))
+
+
+ def test_parse_diff__one_file():
+@@ -52,11 +53,12 @@ def test_parse_diff__multiple_files():
+
+
+ def test_parse_diff__bad_input():
+-    assert False, 'not done'
+-
+-
+-def test_parse_diff__ignore_no_adds():
+-    assert False, 'not done'
++    data = """
++    some dumb stuff
 +    """
-+    if not text:
-+        raise ParseError('No diff provided')
++    with assert_raises(ParseError) as ctx:
++        parse_diff(data)
++    assert_in('Could not parse', str(ctx.exception))
+
+
+ class TestDiffCollection(TestCase):

--- a/tests/fixtures/diff/one_file.txt
+++ b/tests/fixtures/diff/one_file.txt
@@ -1,0 +1,14 @@
+diff --git a/lintreview/diff.py b/lintreview/diff.py
+index 11ce912..1eff317 100644
+--- a/lintreview/diff.py
++++ b/lintreview/diff.py
+@@ -7,6 +7,14 @@ import logging
+ log = logging.getLogger(__name__)
+
+
++def parse_diff(text):
++    """Parse the output of `git diff` into
++    a DiffCollection and set of diff objects
++    """
++    if not text:
++        raise ParseError('No diff provided')

--- a/tests/fixtures/diff/two_files.txt
+++ b/tests/fixtures/diff/two_files.txt
@@ -1,0 +1,53 @@
+diff --git a/lintreview/git.py b/lintreview/git.py
+index b2b5fa7..d054976 100644
+--- a/lintreview/git.py
++++ b/lintreview/git.py
+@@ -148,6 +148,31 @@ def commit(path, author, message):
+     return output
+ 
+ 
++@log_io_error
++def create_branch(path, name):
++    """Create & checkout a local branch based
++    on the currently checked out commit
++    """
++    command = ['git', 'checkout', '-b', name]
++    return_code, output = _process(command, chdir=path)
++    if return_code:
++        raise IOError(u"Unable to create branch {}:{}. {}'".format(
++                      name,
++                      output))
++
++
++@log_io_error
++def branch_exists(path, name):
++    """See if a branch exists"""
++    command = ['git', 'branch']
++    return_code, output = _process(command, chdir=path)
++    if return_code:
++        raise IOError(u"Unable to read branches {}'".format(output))
++    matching = [branch for branch in output.split('\n')
++                if branch.strip('* ') == name]
++    return len(matching) == 1
++
++
+ @log_io_error
+ def push(path, remote, branch):
+     """Push a branch to the named remote"""
+diff --git a/tests/test_git.py b/tests/test_git.py
+index 5f8e33a..d99e938 100644
+--- a/tests/test_git.py
++++ b/tests/test_git.py
+@@ -202,3 +202,12 @@ def test_push__fails():
+         git.push(clone_path, 'origin', 'master')
+     except IOError as e:
+         assert_in('origin:master', str(e))
++
++
++@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
++@with_setup(setup_repo, teardown_repo)
++def test_create_branch():
++    git.create_branch(clone_path, 'testing')
++    eq_(True, git.branch_exists(clone_path, 'master'))
++    eq_(True, git.branch_exists(clone_path, 'testing'))
++    eq_(False, git.branch_exists(clone_path, 'nope'))

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -12,17 +12,17 @@ def test_parse_diff__no_input():
     assert_in('No diff', str(ctx.exception))
 
 
-def test_parse_diff__one_file():
+def test_parse_diff__headers_removed():
     data = load_fixture('diff/one_file.txt')
     out = parse_diff(data)
 
     assert isinstance(out, DiffCollection)
     eq_(1, len(out))
-    eq_(['lintreview/diff.py'], out.get_files())
+    eq_(['tests/test_diff.py'], out.get_files())
 
-    change = out.all_changes('lintreview/diff.py')
+    change = out.all_changes('tests/test_diff.py')
     eq_(1, len(change))
-    eq_('lintreview/diff.py', change[0].filename)
+    eq_('tests/test_diff.py', change[0].filename)
     eq_(None, change[0].commit, 'No commit as changes are just a diff')
 
     # Make sure git diff headers are not in patch
@@ -31,6 +31,18 @@ def test_parse_diff__one_file():
     assert_not_in('--- a', change[0].patch)
     assert_not_in('+++ b', change[0].patch)
     assert_in('@@', change[0].patch)
+
+
+def test_parse_diff__changed_lines_parsed():
+    data = load_fixture('diff/one_file.txt')
+    out = parse_diff(data)
+
+    assert isinstance(out, DiffCollection)
+    change = out.all_changes('tests/test_diff.py')
+    eq_(1, len(change))
+
+    expected = set([6, 9, 10, 56])
+    eq_(expected, change[0].deleted_lines())
 
 
 def test_parse_diff__multiple_files():
@@ -250,5 +262,5 @@ class TestDiff(TestCase):
 
         dels = diff.deleted_lines()
         eq_(3, len(dels), 'incorrect deleted length')
-        eq_(set([116, 118, 147]), dels,
+        eq_(set([117, 119, 148]), dels,
             'deleted line numbers are wrong')

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -33,7 +33,22 @@ def test_parse_diff__one_file():
 
 
 def test_parse_diff__multiple_files():
-    assert False, 'not done'
+    data = load_fixture('diff/two_files.txt')
+    out = parse_diff(data)
+    eq_(2, len(out))
+    eq_(['lintreview/git.py', 'tests/test_git.py'], out.get_files())
+
+    for change in out:
+        assert change.filename, 'has a filename'
+        assert change.commit is None, 'No commit'
+        assert_not_in('git --diff', change.patch)
+        assert_not_in('index', change.patch)
+        assert_not_in('--- a', change.patch)
+        assert_not_in('+++ b', change.patch)
+        assert_in('@@', change.patch)
+    change = out.all_changes('tests/test_git.py')[0]
+    eq_(set([205, 206, 207, 208, 209, 210, 211, 212, 213]),
+        change.added_lines())
 
 
 def test_parse_diff__bad_input():

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -264,3 +264,6 @@ class TestDiff(TestCase):
         eq_(3, len(dels), 'incorrect deleted length')
         eq_(set([117, 119, 148]), dels,
             'deleted line numbers are wrong')
+
+        overlap = diff.added_lines().intersection(diff.deleted_lines())
+        eq_(set([117, 119]), overlap)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -3,12 +3,13 @@ from . import load_fixture, create_pull_files
 from lintreview.diff import DiffCollection, Diff, parse_diff, ParseError
 from unittest import TestCase
 from mock import patch
-from nose.tools import eq_, raises, assert_in, assert_not_in
+from nose.tools import eq_, assert_raises, assert_in, assert_not_in
 
 
-@raises(ParseError)
 def test_parse_diff__no_input():
-    parse_diff('')
+    with assert_raises(ParseError) as ctx:
+        parse_diff('')
+    assert_in('No diff', str(ctx.exception))
 
 
 def test_parse_diff__one_file():
@@ -52,11 +53,12 @@ def test_parse_diff__multiple_files():
 
 
 def test_parse_diff__bad_input():
-    assert False, 'not done'
-
-
-def test_parse_diff__ignore_no_adds():
-    assert False, 'not done'
+    data = """
+    some dumb stuff
+    """
+    with assert_raises(ParseError) as ctx:
+        parse_diff(data)
+    assert_in('Could not parse', str(ctx.exception))
 
 
 class TestDiffCollection(TestCase):


### PR DESCRIPTION
Add the ability to parse text based diffs into `DiffCollection` and `Diff` objects. This will enable future work that will help implement auto-fixers as we'll need ways to compare the modified lines of the fixer output with the original changeset to find intersections.