### PR TITLE
Add config file for puppet-lint

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -373,7 +373,9 @@ You'll need to install it to use it:
 
 *Options*
 
-No options. `.puppet-lintrc` files will be respected, to allow each project to disable
+* `config` Provide a path to a puppet-lint config file.
+
+`.puppet-lint.rc` files will also be respected, to allow each project to disable
 checks. A list of checks can be found by running "puppet-lint --help"
 
 ### Chef:

--- a/lintreview/tools/puppet.py
+++ b/lintreview/tools/puppet.py
@@ -34,6 +34,8 @@ class Puppet(Tool):
             command = ['bundle', 'exec', 'puppet-lint']
         command += ['--log-format',
                     '%{path}:%{linenumber}:%{KIND}:%{message}']
+        if self.options.get('config'):
+            command += ['-c', self.apply_base(self.options['config'])]
         command += files
         output = run_command(
             command,

--- a/tests/fixtures/puppet/puppetlint.rc
+++ b/tests/fixtures/puppet/puppetlint.rc
@@ -1,0 +1,2 @@
+--no-autoloader_layout-check
+--no-trailing_whitespace-check

--- a/tests/tools/test_puppet.py
+++ b/tests/tools/test_puppet.py
@@ -56,3 +56,14 @@ class TestPuppet(TestCase):
 
         freshly_laundered_filename = abspath(self.fixtures[0])
         eq_([], self.problems.all(freshly_laundered_filename))
+
+    @needs_puppet
+    def test_process_files__with_config(self):
+        config = {
+            'config': 'tests/fixtures/puppet/puppetlint.rc'
+        }
+        tool = Puppet(self.problems, config)
+        tool.process_files([self.fixtures[1]])
+
+        eq_([], self.problems.all(abspath(self.fixtures[1])),
+            'Config file should cause no errors on has_errors.pp')


### PR DESCRIPTION
I was having a problem with getting my `.puppet-lint.rc` file in the root of my repository to be honored by lint-review running in docker-compose so I hacked this together.

I briefly experimented with passing `cwd=self.base_path` to the `run_command` call [here](https://github.com/markstory/lint-review/blob/d4a6b4d7d210129d09026efe3668ecd62595b2b3/lintreview/tools/puppet.py#L38), but that didn't work and I didn't spend any more time debugging.