### PR TITLE
Skip fixer commit if maintainer cannot edit

### DIFF
--- a/lintreview/fixers/__init__.py
+++ b/lintreview/fixers/__init__.py
@@ -1,17 +1,16 @@
 from __future__ import absolute_import
 from lintreview.diff import parse_diff, Diff
 from lintreview.fixers.commit_strategy import CommitStrategy
+from lintreview.fixers.error import StrategyError
 import lintreview.git as git
 import logging
 
 log = logging.getLogger(__name__)
+
+
 workflow_strategies = {
     'commit': CommitStrategy
 }
-
-
-class StrategyError(RuntimeError):
-    pass
 
 
 def create_context(review_config, app_config, repo_path,

--- a/lintreview/fixers/__init__.py
+++ b/lintreview/fixers/__init__.py
@@ -14,15 +14,16 @@ class StrategyError(RuntimeError):
     pass
 
 
-def create_context(review_config, app_config, repo_path, branch):
+def create_context(review_config, app_config, repo_path,
+                   repository, pull_request):
     """Create the context used for running fixers"""
-    # TODO Consider making a namedtuple?
     context = {
         'strategy': review_config.fixer_workflow(),
         'enabled': review_config.fixers_enabled(),
         'author': app_config['GITHUB_AUTHOR'],
         'repo_path': repo_path,
-        'remote_branch': branch
+        'pull_request': pull_request,
+        'repository': repository,
     }
     return context
 
@@ -83,6 +84,7 @@ def apply_fixer_diff(original_diffs, fixer_diff, strategy_context):
     try:
         workflow.execute(changes_to_apply)
     except:
+        # TODO rollback changes.
         log.exception('Failed to push fixer diff.')
 
 

--- a/lintreview/fixers/__init__.py
+++ b/lintreview/fixers/__init__.py
@@ -83,8 +83,8 @@ def apply_fixer_diff(original_diffs, fixer_diff, strategy_context):
     try:
         workflow.execute(changes_to_apply)
     except:
-        # TODO rollback changes.
-        log.exception('Failed to push fixer diff.')
+        rollback_changes(strategy_context['repo_path'])
+        log.exception('Failed to push fixer changes')
 
 
 def add_strategy(name, implementation):

--- a/lintreview/fixers/__init__.py
+++ b/lintreview/fixers/__init__.py
@@ -14,15 +14,16 @@ workflow_strategies = {
 
 
 def create_context(review_config, app_config, repo_path,
-                   repository, pull_request):
+                   head_repository, pull_request):
     """Create the context used for running fixers"""
     context = {
         'strategy': review_config.fixer_workflow(),
         'enabled': review_config.fixers_enabled(),
-        'author': app_config['GITHUB_AUTHOR'],
+        'author_name': app_config['GITHUB_AUTHOR_NAME'],
+        'author_email': app_config['GITHUB_AUTHOR_EMAIL'],
         'repo_path': repo_path,
         'pull_request': pull_request,
-        'repository': repository,
+        'repository': head_repository,
     }
     return context
 

--- a/lintreview/fixers/commit_strategy.py
+++ b/lintreview/fixers/commit_strategy.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
+from stat import ST_MODE
+from datetime import datetime
+import os
 import lintreview.git as git
+from lintreview.fixers import StrategyError
 import logging
 
 log = logging.getLogger(__name__)
@@ -13,14 +17,60 @@ class CommitStrategy(object):
     def __init__(self, context):
         self.path = context['repo_path']
         self.author = context['author']
-        self.remote_branch = context['remote_branch']
+        self.pull_request = context['pull_request']
+        self.repository = context['repository']
 
     def execute(self, diffs):
-        git.create_branch(self.path, 'stylefixes')
-        git.checkout(self.path, 'stylefixes')
+        # Reset working tree.
+        git.reset_hard(self.path)
+
+        # Get current commit & tree shas
+        head_commit_sha = self.pull_request.head
+        head_tree_sha = git.tree_sha(self.path, head_commit_sha)
+        treedata = []
+
+        # Apply patches to get new target state.
+        # Use local file system state to create
+        # required git data.
         for diff in diffs:
-            git.apply_cached(self.path, diff.as_diff())
-        git.commit(self.path, self.author, 'Fixing style errors.')
-        git.push(self.path, 'origin', 'stylefixes:' + self.remote_branch)
-        # TODO raise an error that is converted into
-        # a review error when pushing fails due to access/auth issues.
+            git.apply(self.path, diff.as_diff())
+
+            path = self.path + os.sep + diff.filename
+            f = open(path, 'r')
+
+            log.info('Creating blob for %s', diff.filename)
+            blob_sha = self.repository.create_blob(f.read(), 'utf-8')
+            if not blob_sha:
+                raise StrategyError('Could not create blob')
+
+            stat = os.stat(path)
+            treedata.append({
+                'path': diff.filename,
+                'mode': str(oct(stat.st_mode))[1:],
+                'type': 'blob',
+                'sha': blob_sha
+            })
+
+        new_tree = self.repository.create_tree(
+            tree=treedata,
+            base_tree=head_tree_sha)
+        if not new_tree:
+            raise StrategyError('Could not create tree')
+
+        # Add a new commit for the tree
+        new_commit = self.repository.create_commit(
+            tree=new_tree.sha,
+            parents=[head_commit_sha],
+            author={
+                'name': 'lintbot',
+                'email': 'lintbot@mark-story.com',
+                'date': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            },
+            message='Fixing style errors.')
+        if not new_commit:
+            raise StrategyError('Could not create commit')
+
+        # Update the remote branch.
+        self.repository.update_branch(
+            self.pull_request.head_branch,
+            new_commit.sha)

--- a/lintreview/fixers/commit_strategy.py
+++ b/lintreview/fixers/commit_strategy.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
-from datetime import datetime
-from lintreview.fixers.error import FixerError
-import os
+from lintreview.fixers.error import WorkflowError
 import lintreview.git as git
 import logging
 
@@ -17,10 +15,14 @@ class CommitStrategy(object):
         self.path = context['repo_path']
         self.author_name = context['author_name']
         self.author_email = context['author_email']
-        self.repository = context['repository']
         self.pull_request = context['pull_request']
 
     def execute(self, diffs):
+        if not self.pull_request.maintainer_can_modify:
+            msg = ('Cannot apply automatic fixing, '
+                   'as this pull request cannot be '
+                   'modified by maintainers.')
+            raise WorkflowError(msg)
         git.create_branch(self.path, 'stylefixes')
         git.checkout(self.path, 'stylefixes')
         for diff in diffs:

--- a/lintreview/fixers/error.py
+++ b/lintreview/fixers/error.py
@@ -3,6 +3,12 @@ class FixerError(RuntimeError):
     pass
 
 
-class StrategyError(FixerError):
-    """Strategy configuration error"""
+class ConfigurationError(FixerError):
+    """Workflow/fixer configuration error"""
+    pass
+
+
+class WorkflowError(FixerError):
+    """Workflow execution error error.
+    Will be reported as an issue comment."""
     pass

--- a/lintreview/fixers/error.py
+++ b/lintreview/fixers/error.py
@@ -1,0 +1,8 @@
+class FixerError(RuntimeError):
+    """Base class for all fixer related errors"""
+    pass
+
+
+class StrategyError(FixerError):
+    """Strategy configuration error"""
+    pass

--- a/lintreview/git.py
+++ b/lintreview/git.py
@@ -124,32 +124,6 @@ def apply_cached(path, patch):
 
 
 @log_io_error
-def apply(path, patch):
-    """Apply a patch to the working tree.
-    """
-    command = ['git', 'apply']
-    if not len(patch):
-        return ''
-    return_code, output = _process(command, input_val=patch, chdir=path)
-    if return_code:
-        raise IOError(u"Unable to apply changes '{}'".format(output))
-    return output
-
-
-@log_io_error
-def tree_sha(path, commit_sha):
-    """Get the tree sha for a given commit.
-    """
-    command = ['git', 'cat-file', '-p', commit_sha]
-    return_code, output = _process(command, chdir=path)
-    if return_code:
-        raise IOError(u"Unable to apply changes '{}'".format(output))
-    tree_line = output.split('\n')[0]
-    assert tree_line.startswith('tree'), 'Should start with tree'
-    return tree_line.split(' ')[1]
-
-
-@log_io_error
 def status(path):
     """Get the working status of path"""
     command = ['git', 'status', '-s']

--- a/lintreview/git.py
+++ b/lintreview/git.py
@@ -124,6 +124,32 @@ def apply_cached(path, patch):
 
 
 @log_io_error
+def apply(path, patch):
+    """Apply a patch to the working tree.
+    """
+    command = ['git', 'apply']
+    if not len(patch):
+        return ''
+    return_code, output = _process(command, input_val=patch, chdir=path)
+    if return_code:
+        raise IOError(u"Unable to apply changes '{}'".format(output))
+    return output
+
+
+@log_io_error
+def tree_sha(path, commit_sha):
+    """Get the tree sha for a given commit.
+    """
+    command = ['git', 'cat-file', '-p', commit_sha]
+    return_code, output = _process(command, chdir=path)
+    if return_code:
+        raise IOError(u"Unable to apply changes '{}'".format(output))
+    tree_line = output.split('\n')[0]
+    assert tree_line.startswith('tree'), 'Should start with tree'
+    return tree_line.split(' ')[1]
+
+
+@log_io_error
 def status(path):
     """Get the working status of path"""
     command = ['git', 'status', '-s']

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -55,9 +55,6 @@ class Processor(object):
 
     def apply_fixers(self, review_config, tool_list, files_to_check):
         try:
-            # TODO use the head repo here,
-            # as fixers need to push/operate on the
-            # head repository.
             fixer_context = fixers.create_context(
                 review_config,
                 self._config,

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -4,7 +4,7 @@ import lintreview.tools as tools
 import lintreview.fixers as fixers
 
 from lintreview.diff import DiffCollection
-from lintreview.fixers import StrategyError
+from lintreview.fixers.error import ConfigurationError, WorkflowError
 from lintreview.review import Problems, Review, IssueComment
 
 log = logging.getLogger(__name__)
@@ -70,11 +70,13 @@ class Processor(object):
                 self._changes,
                 fixer_diff,
                 fixer_context)
-        except StrategyError as e:
+        except (ConfigurationError, WorkflowError) as e:
+            log.warn('Fixer application failed. Got %s', e)
             message = u'Unable to apply fixers. {}'.format(e)
             self.problems.add(IssueComment(message))
         except Exception as e:
-            log.warn('Unable to apply fixers. Got %s', e)
+            log.warn('Fixer application failed, '
+                     'rolling back working tree. Got %s', e)
             fixers.rollback_changes(self._target_path)
 
     def publish(self):

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -55,11 +55,15 @@ class Processor(object):
 
     def apply_fixers(self, review_config, tool_list, files_to_check):
         try:
+            # TODO use the head repo here,
+            # as fixers need to push/operate on the
+            # head repository.
             fixer_context = fixers.create_context(
                 review_config,
                 self._config,
                 self._target_path,
-                self._pull_request.head_branch
+                self._repository,
+                self._pull_request,
             )
             fixer_diff = fixers.run_fixers(
                 tool_list,

--- a/lintreview/repo.py
+++ b/lintreview/repo.py
@@ -138,6 +138,11 @@ class GithubPullRequest(object):
         data = self.pull.as_dict()
         return data['head']['ref']
 
+    @property
+    def maintainer_can_modify(self):
+        data = self.pull.as_dict()
+        return data['maintainer_can_modify']
+
     def head_repository(self, app_config):
         """Get a GithubRepository for the head side of the pull request.
         """

--- a/lintreview/repo.py
+++ b/lintreview/repo.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from json import dumps
 import lintreview.github as github
 import logging
 
@@ -58,36 +57,6 @@ class GithubRepository(object):
             description,
             context)
 
-    def create_blob(self, *args, **kwargs):
-        """Create a blob object
-        """
-        return self.repository().create_blob(*args, **kwargs)
-
-    def create_tree(self, *args, **kwargs):
-        """Create a tree object
-        """
-        log.info('Creating new tree object')
-        return self.repository().create_tree(*args, **kwargs)
-
-    def create_commit(self, *args, **kwargs):
-        """Create a commit object
-        """
-        log.info('Creating commit for tree %s', kwargs['tree'])
-        return self.repository().create_commit(*args, **kwargs)
-
-    def update_branch(self, branch, sha):
-        """Update a branch
-
-        There is no github3 wrapper API for this.
-        """
-        log.info('Updating %s to %s', branch, sha)
-
-        repo = self.repository()
-        ref = u"heads/{}".format(branch)
-        url = repo._build_url('git', 'refs', ref, base_url=repo._api)
-        data = {'sha': sha}
-        return repo._json(repo._patch(url, data=dumps(data)), 201)
-
 
 class GithubPullRequest(object):
     """Abstract the underlying github models.
@@ -142,15 +111,6 @@ class GithubPullRequest(object):
     def maintainer_can_modify(self):
         data = self.pull.as_dict()
         return data['maintainer_can_modify']
-
-    def head_repository(self, app_config):
-        """Get a GithubRepository for the head side of the pull request.
-        """
-        data = self.pull.as_dict()
-        return GithubRepository(
-            app_config,
-            data['head']['repo']['owner']['login'],
-            data['head']['repo']['name'])
 
     def commits(self):
         return self.pull.commits()

--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -52,6 +52,11 @@ def process_pull_request(user, repo_name, number, lintrc):
         target_path = git.get_repo_path(user, repo_name, number, config)
         git.clone_or_update(config, head_repo, target_path, pr_head)
 
+        # TODO perhaps remove repo from here.
+        # For updating pull requests we need the head
+        # repo, because the pull request
+        # could be coming from a fork.
+        # Currently `repo` is the base repo.
         processor = Processor(repo, pull_request,
                               target_path, config)
         processor.load_changes()

--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -34,7 +34,7 @@ def process_pull_request(user, repo_name, number, lintrc):
         repo = GithubRepository(config, user, repo_name)
         pull_request = repo.pull_request(number)
 
-        head_repo = pull_request.clone_url
+        clone_url = pull_request.clone_url
 
         pr_head = pull_request.head
         target_branch = pull_request.target_branch
@@ -50,13 +50,8 @@ def process_pull_request(user, repo_name, number, lintrc):
 
         # Clone/Update repository
         target_path = git.get_repo_path(user, repo_name, number, config)
-        git.clone_or_update(config, head_repo, target_path, pr_head)
+        git.clone_or_update(config, clone_url, target_path, pr_head)
 
-        # TODO perhaps remove repo from here.
-        # For updating pull requests we need the head
-        # repo, because the pull request
-        # could be coming from a fork.
-        # Currently `repo` is the base repo.
         processor = Processor(repo, pull_request,
                               target_path, config)
         processor.load_changes()

--- a/settings.sample.py
+++ b/settings.sample.py
@@ -87,7 +87,8 @@ SSL_CA_BUNDLE = None
 SUMMARY_THRESHOLD = env('LINTREVIEW_SUMMARY_THRESHOLD', 50, int)
 
 # Used as the author information when making commits
-GITHUB_AUTHOR = 'lintreview <lintreview@example.com>'
+GITHUB_AUTHOR_NAME = 'lintreview'
+GITHUB_AUTHOR_EMAIL = 'lintreview@example.com'
 
 # Status Configuration
 ######################

--- a/tests/fixers/test_commit_strategy.py
+++ b/tests/fixers/test_commit_strategy.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
 from lintreview.fixers.commit_strategy import CommitStrategy
+from lintreview.fixers.error import WorkflowError
 from mock import patch, Mock, sentinel
-from nose.tools import assert_raises, with_setup, eq_
+from nose.tools import assert_in, assert_raises, with_setup, eq_
 from ..test_git import setup_repo, teardown_repo, clone_path
 
 
 def test_init_key_requirements():
-    keys = ('repo_path', 'author', 'remote_branch')
-    values = ('some/path', 'lintbot', 'awesome')
+    keys = ('repo_path', 'author_email', 'author_name',
+            'pull_request')
+    values = ('some/path', 'lintbot', 'bot@example.com',
+              'pull#1')
     for key in keys:
         context = dict(zip(keys, values))
         del context[key]
@@ -19,11 +22,15 @@ def test_init_key_requirements():
 @patch('lintreview.git.commit')
 @patch('lintreview.git.push')
 @patch('lintreview.git.apply_cached')
-def test_init_execute__git_flow(mock_apply, mock_push, mock_commit):
+def test_execute__git_flow(mock_apply, mock_push, mock_commit):
+    mock_pull = Mock(
+        head_branch='patch-1',
+        maintainer_can_modify=True)
     context = {
         'repo_path': clone_path,
-        'author': 'lintbot <lint@example.com>',
-        'remote_branch': 'things'
+        'author_name': 'lintbot',
+        'author_email': 'lint@example.com',
+        'pull_request': mock_pull
     }
     strategy = CommitStrategy(context)
 
@@ -34,12 +41,35 @@ def test_init_execute__git_flow(mock_apply, mock_push, mock_commit):
 
     mock_commit.assert_called_with(
         clone_path,
-        context['author'],
+        'lintbot <lint@example.com>',
         'Fixing style errors.')
     mock_push.assert_called_with(
         clone_path,
         'origin',
-        'stylefixes:things')
+        'stylefixes:patch-1')
     mock_apply.assert_called_with(
         clone_path,
         sentinel.diff)
+
+
+@patch('lintreview.git.commit')
+def test_execute__no_maintainer_modify(mock_commit):
+    mock_pull = Mock(
+        head_branch='patch-1',
+        maintainer_can_modify=False)
+    context = {
+        'repo_path': clone_path,
+        'author_name': 'lintbot',
+        'author_email': 'lint@example.com',
+        'pull_request': mock_pull
+    }
+    strategy = CommitStrategy(context)
+
+    diff = Mock()
+    diff.as_diff.return_value = sentinel.diff
+    with assert_raises(WorkflowError) as err:
+        strategy.execute([diff])
+
+    assert_in('Cannot apply automatic fixing', str(err.exception))
+    assert_in('modified by maintainers', str(err.exception))
+    eq_(0, mock_commit.call_count)

--- a/tests/fixers/test_init.py
+++ b/tests/fixers/test_init.py
@@ -6,7 +6,7 @@ from lintreview.diff import parse_diff, Diff
 from lintreview.tools.phpcs import Phpcs
 from lintreview.utils import composer_exists
 from unittest import skipIf
-from mock import Mock, sentinel, patch
+from mock import Mock, sentinel
 from nose.tools import (
     assert_raises,
     assert_in,

--- a/tests/fixers/test_init.py
+++ b/tests/fixers/test_init.py
@@ -6,7 +6,7 @@ from lintreview.diff import parse_diff, Diff
 from lintreview.tools.phpcs import Phpcs
 from lintreview.utils import composer_exists
 from unittest import skipIf
-from mock import Mock
+from mock import Mock, sentinel, patch
 from nose.tools import (
     assert_raises,
     assert_in,
@@ -18,7 +18,8 @@ from ..test_git import setup_repo, teardown_repo, clone_path
 
 
 app_config = {
-    'GITHUB_AUTHOR': 'bot <bot@example.com>'
+    'GITHUB_AUTHOR_NAME': 'bot',
+    'GITHUB_AUTHOR_EMAIL': 'bot@example.com'
 }
 
 phpcs_missing = not(composer_exists('phpcs'))
@@ -110,7 +111,8 @@ def test_apply_fixer_diff__missing_strategy_context():
     assert_in('Could not create strategy', str(err.exception))
 
 
-def test_apply_fixer_diff__strategy_execution_fails():
+@patch('lintreview.fixers.rollback_changes')
+def test_apply_fixer_diff__strategy_execution_fails(mock_rollback):
     strategy_factory = Mock()
     strategy = Mock()
     strategy.execute.side_effect = RuntimeError
@@ -123,10 +125,11 @@ def test_apply_fixer_diff__strategy_execution_fails():
     original = parse_diff(original)
     updated = parse_diff(updated)
 
-    context = {'strategy': 'mock'}
+    context = {'strategy': 'mock', 'repo_path': '/tmp/things'}
     out = fixers.apply_fixer_diff(original, updated, context)
     eq_(1, strategy.execute.call_count)
     eq_(out, None, 'No output and no exception')
+    assert mock_rollback.called, 'Should rollback on failure'
 
 
 def test_apply_fixer_diff__calls_execute():
@@ -148,15 +151,22 @@ def test_apply_fixer_diff__calls_execute():
 
 def test_create_context():
     config = build_review_config(fixer_ini)
-    context = fixers.create_context(config, app_config, clone_path, 'fixes')
+    context = fixers.create_context(
+        config, app_config, clone_path,
+        sentinel.repo, sentinel.pull_request)
+
     eq_('commit', context['strategy'])
-    eq_(app_config['GITHUB_AUTHOR'], context['author'])
+    eq_(app_config['GITHUB_AUTHOR_EMAIL'], context['author_email'])
+    eq_(app_config['GITHUB_AUTHOR_NAME'], context['author_name'])
     eq_(clone_path, context['repo_path'])
-    eq_('fixes', context['remote_branch'])
+    eq_(sentinel.repo, context['repository'])
+    eq_(sentinel.pull_request, context['pull_request'])
 
 
 def test_create_context__missing_key_raises():
     config = build_review_config(fixer_ini)
     with assert_raises(KeyError):
         empty = {}
-        fixers.create_context(config, empty, clone_path, 'fixes')
+        fixers.create_context(
+            config, empty, clone_path,
+            sentinel.repo, sentinel.pull_request)

--- a/tests/fixers/test_init.py
+++ b/tests/fixers/test_init.py
@@ -88,7 +88,7 @@ def test_apply_fixer_diff__missing_strategy_key():
     original = Mock()
     changed = Mock()
     context = {}
-    with assert_raises(fixers.StrategyError) as err:
+    with assert_raises(fixers.ConfigurationError) as err:
         fixers.apply_fixer_diff(original, changed, context)
     assert_in('Missing', str(err.exception))
 
@@ -97,7 +97,7 @@ def test_apply_fixer_diff__invalid_strategy():
     original = Mock()
     changed = Mock()
     context = {'strategy': 'bad stategy'}
-    with assert_raises(fixers.StrategyError) as err:
+    with assert_raises(fixers.ConfigurationError) as err:
         fixers.apply_fixer_diff(original, changed, context)
     assert_in('Unknown', str(err.exception))
 
@@ -106,30 +106,9 @@ def test_apply_fixer_diff__missing_strategy_context():
     original = Mock()
     changed = Mock()
     context = {'strategy': 'commit'}
-    with assert_raises(fixers.StrategyError) as err:
+    with assert_raises(fixers.ConfigurationError) as err:
         fixers.apply_fixer_diff(original, changed, context)
-    assert_in('Could not create strategy', str(err.exception))
-
-
-@patch('lintreview.fixers.rollback_changes')
-def test_apply_fixer_diff__strategy_execution_fails(mock_rollback):
-    strategy_factory = Mock()
-    strategy = Mock()
-    strategy.execute.side_effect = RuntimeError
-    strategy_factory.return_value = strategy
-
-    fixers.add_strategy('mock', strategy_factory)
-
-    original = load_fixture('diff/intersecting_hunks_original.txt')
-    updated = load_fixture('diff/intersecting_hunks_updated.txt')
-    original = parse_diff(original)
-    updated = parse_diff(updated)
-
-    context = {'strategy': 'mock', 'repo_path': '/tmp/things'}
-    out = fixers.apply_fixer_diff(original, updated, context)
-    eq_(1, strategy.execute.call_count)
-    eq_(out, None, 'No output and no exception')
-    assert mock_rollback.called, 'Should rollback on failure'
+    assert_in('Could not create commit workflow', str(err.exception))
 
 
 def test_apply_fixer_diff__calls_execute():

--- a/tests/fixtures/pull_request.json
+++ b/tests/fixtures/pull_request.json
@@ -240,6 +240,7 @@
         "html_url": "https://github.com/markstory/lint-test/pull/1",
         "id": 4050302,
         "issue_url": "https://github.com/markstory/lint-test/issues/1",
+        "maintainer_can_modify": true,
         "merge_commit_sha": null,
         "mergeable": null,
         "mergeable_state": "unknown",

--- a/tests/fixtures/pull_request_closed.json
+++ b/tests/fixtures/pull_request_closed.json
@@ -248,6 +248,7 @@
         "html_url": "https://github.com/markstory/lint-test/pull/1",
         "id": 4050302,
         "issue_url": "https://github.com/markstory/lint-test/issues/1",
+        "maintaier_can_modify": true,
         "merge_commit_sha": "c491264ceb8403941f7222c42e311169be928224",
         "mergeable": true,
         "mergeable_state": "clean",

--- a/tests/fixtures/pull_request_update.json
+++ b/tests/fixtures/pull_request_update.json
@@ -248,6 +248,7 @@
         "html_url": "https://github.com/markstory/lint-test/pull/1",
         "id": 4050302,
         "issue_url": "https://github.com/markstory/lint-test/issues/1",
+        "maintaier_can_modify": true,
         "merge_commit_sha": "f1116c3c9a91943f49a48ec2b22415a0e9c46594",
         "mergeable": null,
         "mergeable_state": "unknown",

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -179,6 +179,17 @@ class TestGithubPullRequest(TestCase):
             data=review)
         assert self.model._json.called
 
+    def test_maintainer_can_modify(self):
+        pull = GithubPullRequest(self.model)
+        eq_(True, pull.maintainer_can_modify)
+
+        fixture = load_fixture('pull_request.json')
+        data = json.loads(fixture)['pull_request']
+        data['maintainer_can_modify'] = False
+
+        model = PullRequest(data)
+        eq_(False, model.maintainer_can_modify)
+
 
 @contextmanager
 def add_ok_label(pull_request, *labels, **kw):


### PR DESCRIPTION
This started out as an exercise in using the git APIs to get around perceived authorship issues in fixer commits, but that experiment didn't pan out. Instead, I'm fixing an issue with un-editable pull requests and making errors better, and configuration simpler.