### PR TITLE
Mark pull requests with no additions as passing.

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -267,7 +267,7 @@ class Review(object):
         if self.config.get('PULLREQUEST_STATUS', True):
             self._repo.create_status(
                 self._pr.head,
-                'error',
+                'success',
                 body
             )
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -284,7 +284,7 @@ class TestReview(TestCase):
 
         self.repo.create_status.assert_called_with(
             self.pr.head,
-            'error',
+            'success',
             msg)
 
         self.pr.create_comment.assert_called_with(msg)


### PR DESCRIPTION
While GitHub *can* return no diffs on huge pulls, most of the time a diff with no additions is simply all deletions.

Refs #114