### PR TITLE
Fix sasslint failing on multiple files.

### DIFF
--- a/lintreview/tools/sasslint.py
+++ b/lintreview/tools/sasslint.py
@@ -41,4 +41,7 @@ class Sasslint(Tool):
             'nodejs',
             command,
             source_dir=self.base_path)
-        process_checkstyle(self.problems, output, docker.strip_base)
+        # sass-lint is very silly and outputs multiple xml documents.
+        # One for each file...
+        for line in output.split("\n"):
+            process_checkstyle(self.problems, line, docker.strip_base)

--- a/tests/fixtures/sasslint/has_more_errors.scss
+++ b/tests/fixtures/sasslint/has_more_errors.scss
@@ -1,0 +1,9 @@
+.thinger {
+  padding: 100px;
+  width: 100px;
+  @include bar(green);
+}
+
+@mixin bar($color) {
+  color: $color;
+}

--- a/tests/tools/test_sasslint.py
+++ b/tests/tools/test_sasslint.py
@@ -11,6 +11,7 @@ class TestSasslint(TestCase):
     fixtures = [
         'tests/fixtures/sasslint/no_errors.scss',
         'tests/fixtures/sasslint/has_errors.scss',
+        'tests/fixtures/sasslint/has_more_errors.scss',
     ]
 
     def setUp(self):
@@ -47,12 +48,15 @@ class TestSasslint(TestCase):
         eq_(expected, problems[0])
 
     @requires_image('nodejs')
-    def test_process_files_two_files(self):
+    def test_process_files__multiple_files(self):
         self.tool.process_files(self.fixtures)
 
         eq_([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
+        eq_(1, len(problems))
+
+        problems = self.problems.all(self.fixtures[2])
         eq_(1, len(problems))
 
     @requires_image('nodejs')


### PR DESCRIPTION
sasslint hilariously outputs one xml document for *each* file.