### PR TITLE
Add fixer to golint

### DIFF
--- a/docker/golint.Dockerfile
+++ b/docker/golint.Dockerfile
@@ -1,9 +1,5 @@
 FROM alpine:3.7
 
-# Install go 1.8 from tarball
-ENV GOLANG_VERSION 1.8.5
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 4f8aeea2033a2d731f2f75c4d0a4995b357b22af56ed69b3015f4291fca4d42d
 ENV GOPATH=/tool/golang
 
 RUN mkdir /tool \

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -87,8 +87,7 @@ class Phpcs(Tool):
         return command
 
     def has_fixer(self):
-        """
-        PHPCS has a fixer that can be enabled through configuration.
+        """PHPCS has a fixer that can be enabled through configuration.
         """
         return bool(self.options.get('fixer', False))
 


### PR DESCRIPTION
golint doesn't have a fixer mode itself, but we can attempt to correct common code style issues with gofmt. This provides some assistance around auto-formatting