### PR TITLE
Add missing base path stripping.

### DIFF
--- a/lintreview/tools/ansible.py
+++ b/lintreview/tools/ansible.py
@@ -41,4 +41,4 @@ class Ansible(Tool):
         output = output.split("\n")
         output.sort()
 
-        process_quickfix(self.problems, output, lambda x: x)
+        process_quickfix(self.problems, output, docker.strip_base)

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -59,7 +59,7 @@ class Flake8(Tool):
             return False
 
         output = output.split("\n")
-        process_quickfix(self.problems, output, lambda name: name)
+        process_quickfix(self.problems, output, docker.strip_base)
 
     def make_command(self, files):
         command = ['flake8', '--isolated']

--- a/lintreview/tools/jsonlint.py
+++ b/lintreview/tools/jsonlint.py
@@ -43,4 +43,4 @@ class Jsonlint(Tool):
             return False
 
         output = output.split("\n")
-        process_quickfix(self.problems, output, lambda x: x)
+        process_quickfix(self.problems, output, docker.strip_base)

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -54,7 +54,7 @@ class Pep8(Tool):
             return False
         output = output.split("\n")
 
-        process_quickfix(self.problems, output, lambda name: name)
+        process_quickfix(self.problems, output, docker.strip_base)
 
     def has_fixer(self):
         """

--- a/lintreview/tools/yamllint.py
+++ b/lintreview/tools/yamllint.py
@@ -46,4 +46,4 @@ class Yamllint(Tool):
             return False
 
         output = output.split("\n")
-        process_quickfix(self.problems, output, lambda x: x)
+        process_quickfix(self.problems, output, docker.strip_base)

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -53,6 +53,20 @@ class TestFlake8(TestCase):
         assert_in('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
+    def test_process_absolute_container_path(self):
+        fixtures = ['/src/' + path for path in self.fixtures]
+        self.tool.process_files(fixtures)
+
+        eq_([], self.problems.all(self.fixtures[0]))
+
+        problems = self.problems.all(self.fixtures[1])
+        assert len(problems) >= 6
+
+        eq_(2, problems[0].line)
+        eq_(2, problems[0].position)
+        assert_in('multiple imports on one line', problems[0].body)
+
+    @requires_image('python2')
     def test_config_options_and_process_file(self):
         options = {
             'ignore': 'F4,W603',

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -15,7 +15,7 @@ class TestFlake8(TestCase):
 
     def setUp(self):
         self.problems = Problems()
-        self.tool = Flake8(self.problems, {'config': ''}, root_dir)
+        self.tool = Flake8(self.problems, {}, root_dir)
 
     def test_match_file(self):
         self.assertFalse(self.tool.match_file('test.php'))

--- a/tests/tools/test_pep8.py
+++ b/tests/tools/test_pep8.py
@@ -59,6 +59,16 @@ class TestPep8(TestCase):
         eq_(expected, problems[5])
 
     @requires_image('python2')
+    def test_process_absolute_container_path(self):
+        fixtures = ['/src/' + path for path in self.fixtures]
+        self.tool.process_files(fixtures)
+
+        eq_([], self.problems.all(self.fixtures[0]))
+
+        problems = self.problems.all(self.fixtures[1])
+        assert len(problems) >= 6
+
+    @requires_image('python2')
     def test_process_files__ignore(self):
         options = {
             'ignore': 'E2,W603'


### PR DESCRIPTION
Tools sometimes include the /src directory. Instead of nooping paths, we should strip off the container prefix if it exists.