### PR TITLE
Fix settings not being reflected in Docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     depends_on:
       - broker
       - worker
+    volumes:
+      - ./settings.py:/code/settings.py
   worker:
     image: markstory/lint-review
     command:
@@ -52,6 +54,7 @@ services:
       C_FORCE_ROOT: "true"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./settings.py:/code/settings.py
     links:
       - broker
     networks:


### PR DESCRIPTION
Fixes #193 

After the initial `docker-compose up -d ...` instructed in [Running lintreview services in Docker
](https://github.com/markstory/lint-review#running-lintreview-services-in-docker) the `web` and `worker` containers don't recognize any changes in `settings.py`