### PR TITLE
Add tests for docker unicode problems.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 ENV REFRESHED_AT 2018-02-24
+ENV LANG=en_US.UTF-8
 
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 ENV REFRESHED_AT 2018-02-24
 ENV LANG=en_US.UTF-8
-ENV LC_ALL=C
+ENV LC_ALL=en_US.UTF-8
 
 RUN apt-get update && \
     apt-get install -y \
@@ -12,6 +12,7 @@ RUN apt-get update && \
     zlib1g-dev \
     docker.io \
     build-essential && \
+    dpkg-reconfigure locales && \
     apt-get -y autoremove && \
     apt-get -y clean  && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 ENV REFRESHED_AT 2018-02-24
 ENV LANG=en_US.UTF-8
+ENV LC_ALL=C
 
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     libffi-dev \
     zlib1g-dev \
     docker.io \
+    language-pack-en \
     build-essential && \
     dpkg-reconfigure locales && \
     apt-get -y autoremove && \

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -82,12 +82,11 @@ def run(image, command, source_dir, env=None, timeout=None):
     cmd += env_args
     cmd.append(image)
 
-    # Make all the arguments into unicode strings.
+    # Make all the arguments into bytestr strings.
     # to get around encoding issues.
-    cmd = [arg.encode('utf8') for arg in cmd]
     cmd += [six.text_type(arg).encode('utf8') for arg in command]
 
-    log.debug('Running %s', ' '.join(cmd))
+    log.debug(u'Running {}'.format(cmd))
     process = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
@@ -95,8 +94,12 @@ def run(image, command, source_dir, env=None, timeout=None):
         stderr=subprocess.PIPE,
         universal_newlines=True)
 
+    # Get output bytes/string
     output, error = process.communicate()
     output = error + output
     log.debug('Container output was: %s', output)
 
+    # Workaround for bytestr in py2 and str in py3
+    if isinstance(output, six.binary_type):
+        return output.decode('utf8')
     return output

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -81,6 +81,9 @@ def run(image, command, source_dir, env=None, timeout=None):
     ]
     cmd += env_args
     cmd.append(image)
+
+    # Make all the arguments into unicode strings.
+    # to get around encoding issues.
     cmd = [arg.encode('utf8') for arg in cmd]
     cmd += [six.text_type(arg).encode('utf8') for arg in command]
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import lintreview.docker as docker
 from nose.tools import eq_
+from tests import requires_image, test_dir
 
 
 def test_replace_basedir():
@@ -23,3 +24,10 @@ def test_apply_base():
     eq_('/src/some/thing.py', docker.apply_base('some/thing.py'))
     eq_('thing.py', docker.apply_base('/some/thing.py'))
     eq_('thing.py', docker.apply_base('/some/../../thing.py'))
+
+
+@requires_image('python2')
+def test_run__unicode():
+    cmd = ['echo', u"\u2620"]
+    output = docker.run('python2', cmd, test_dir)
+    eq_(output, u"\u2620\n".encode('utf8'))

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -30,4 +30,4 @@ def test_apply_base():
 def test_run__unicode():
     cmd = ['echo', u"\u2620"]
     output = docker.run('python2', cmd, test_dir)
-    eq_(output, u"\u2620\n".encode('utf8'))
+    eq_(output, u"\u2620\n")


### PR DESCRIPTION
These tests will likely not pass on 3.6 because unicode is a hot mess.