### PR TITLE
Add fixer support for puppet-lint

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -391,6 +391,8 @@ You'll need to install it to use it:
 *Options*
 
 * `config` Provide a path to a puppet-lint config file.
+* `fixer_ignore` A comma separated list of linter checks to ignore when running
+  the fixer.
 
 `.puppet-lint.rc` files will also be respected, to allow each project to disable
 checks. A list of checks can be found by running "puppet-lint --help"

--- a/lintreview/tools/puppet.py
+++ b/lintreview/tools/puppet.py
@@ -27,11 +27,7 @@ class Puppet(Tool):
         Run code checks with puppet-lint
         """
         log.debug('Processing %s files with %s', files, self.name)
-        command = ['bundle', 'exec', 'puppet-lint']
-        command += ['--log-format',
-                    '%{path}:%{line}:%{column}:%{KIND}:%{message}']
-        if self.options.get('config'):
-            command += ['-c', self.apply_base(self.options['config'])]
+        command = self._create_command()
         command += files
         output = docker.run('ruby2', command, self.base_path)
 
@@ -41,3 +37,34 @@ class Puppet(Tool):
 
         output = output.split("\n")
         process_quickfix(self.problems, output, docker.strip_base)
+
+    def _create_command(self):
+        command = ['bundle', 'exec', 'puppet-lint']
+        command += ['--log-format',
+                    '%{path}:%{line}:%{column}:%{KIND}:%{message}']
+        if self.options.get('config'):
+            command += ['-c', self.apply_base(self.options['config'])]
+        return command
+
+    def has_fixer(self):
+        """
+        puppet-lint has a fixer that can be enabled through configuration.
+        """
+        return bool(self.options.get('fixer', False))
+
+    def process_fixer(self, files):
+        """
+        Run puppet-lint in fixer mode.
+        """
+        command = self.create_fixer_command(files)
+        docker.run('ruby2', command, self.base_path)
+
+    def create_fixer_command(self, files):
+        command = self._create_command()
+        command.append('--fix')
+
+        if self.options.get('fixer_ignore'):
+            for check in self.options['fixer_ignore'].split(','):
+                command.append('--no-{0}-check'.format(check.replace(' ', '')))
+        command += files
+        return command

--- a/lintreview/tools/puppet.py
+++ b/lintreview/tools/puppet.py
@@ -65,6 +65,6 @@ class Puppet(Tool):
 
         if self.options.get('fixer_ignore'):
             for check in self.options['fixer_ignore'].split(','):
-                command.append('--no-{0}-check'.format(check.replace(' ', '')))
+                command.append('--no-{0}-check'.format(check.strip()))
         command += files
         return command

--- a/tests/fixtures/puppet/has_errors.pp
+++ b/tests/fixtures/puppet/has_errors.pp
@@ -1,4 +1,5 @@
 # class foo
 class foo {
   $has_trailing_whitespace = 'yes' 
+  $quoted_boolean = 'true'
 }

--- a/tests/tools/test_puppet.py
+++ b/tests/tools/test_puppet.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.puppet import Puppet
 from unittest import TestCase
-from nose.tools import eq_
+from nose.tools import eq_, assert_in
 from operator import attrgetter
-from tests import root_dir, requires_image
+from tests import root_dir, requires_image, read_file, read_and_restore_file
 
 
 class TestPuppet(TestCase):
@@ -36,6 +36,7 @@ class TestPuppet(TestCase):
         expected_problems = [
             Comment(filename, 2, 2, 'ERROR:foo not in autoload module layout'),
             Comment(filename, 3, 3, 'ERROR:trailing whitespace found'),
+            Comment(filename, 4, 4, 'WARNING:quoted boolean value found')
         ]
 
         problems = sorted(self.problems.all(filename), key=attrgetter('line'))
@@ -46,7 +47,7 @@ class TestPuppet(TestCase):
         self.tool.process_files(self.fixtures)
 
         linty_filename = self.fixtures[1]
-        eq_(2, len(self.problems.all(linty_filename)))
+        eq_(3, len(self.problems.all(linty_filename)))
 
         freshly_laundered_filename = self.fixtures[0]
         eq_([], self.problems.all(freshly_laundered_filename))
@@ -61,3 +62,52 @@ class TestPuppet(TestCase):
 
         eq_([], self.problems.all(self.fixtures[1]),
             'Config file should cause no errors on has_errors.pp')
+
+    def test_has_fixer__not_enabled(self):
+        tool = Puppet(self.problems, {}, root_dir)
+        eq_(False, tool.has_fixer())
+
+    def test_has_fixer__enabled(self):
+        tool = Puppet(self.problems, {'fixer': True}, root_dir)
+        eq_(True, tool.has_fixer())
+
+    @requires_image('ruby2')
+    def test_execute_fixer(self):
+        tool = Puppet(self.problems, {'fixer': True}, root_dir)
+
+        original = read_file(self.fixtures[1])
+        tool.execute_fixer(self.fixtures)
+
+        updated = read_and_restore_file(self.fixtures[1], original)
+        assert original != updated, 'File content should change.'
+        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+
+    @requires_image('ruby2')
+    def test_execute_fixer__fewer_problems_remain(self):
+        tool = Puppet(self.problems, {'fixer': True}, root_dir)
+
+        # The fixture file should have fixable problems fixed
+        original = read_file(self.fixtures[1])
+        tool.execute_fixer(self.fixtures)
+        tool.process_files(self.fixtures)
+
+        read_and_restore_file(self.fixtures[1], original)
+        eq_(1, len(self.problems.all()), 'Most errors should be fixed')
+        assert_in('autoload module layout', self.problems.all()[0].body)
+
+    @requires_image('ruby2')
+    def test_execute_fixer__fixer_ignore(self):
+        puppet_config = {
+            'fixer': True,
+            'fixer_ignore': 'quoted_booleans, variable_is_lowercase',
+        }
+        tool = Puppet(self.problems, puppet_config, root_dir)
+
+        original = read_file(self.fixtures[1])
+        tool.execute_fixer(self.fixtures)
+        tool.process_files(self.fixtures)
+
+        read_and_restore_file(self.fixtures[1], original)
+        eq_(2, len(self.problems.all()), 'Most errors should be fixed')
+        assert_in('autoload module layout', self.problems.all()[0].body)
+        assert_in('quoted boolean', self.problems.all()[1].body)

--- a/tests/tools/test_puppet.py
+++ b/tests/tools/test_puppet.py
@@ -109,5 +109,7 @@ class TestPuppet(TestCase):
 
         read_and_restore_file(self.fixtures[1], original)
         eq_(2, len(self.problems.all()), 'Most errors should be fixed')
-        assert_in('autoload module layout', self.problems.all()[0].body)
-        assert_in('quoted boolean', self.problems.all()[1].body)
+
+        problems = sorted(self.problems.all(), key=attrgetter('line'))
+        assert_in('ERROR:foo not in autoload module layout', problems[0].body)
+        assert_in('WARNING:quoted boolean value', problems[1].body)


### PR DESCRIPTION
Certain automated linter fixes (e.g. quoted booleans) can cause problems if
they're automatically applied, but are still worth surfacing for review
by humans

~It's probably worth noting that I haven't actually run this against a PR, but the tests are passing. I mostly just copied tests from the Rubocop tests, but they seem reasonable.~

Before I left the office this afternoon, I ran through a PR on a GitHub Enterprise instance using this code and it worked as expected for me