### PR TITLE
Always clean up working directory

### DIFF
--- a/lintreview/tasks.py
+++ b/lintreview/tasks.py
@@ -58,10 +58,15 @@ def process_pull_request(user, repo_name, number, lintrc):
         log.info('Completed lint processing for %s/%s/%s' % (
             user, repo_name, number))
 
-        git.destroy(target_path)
-        log.info('Cleaned up pull request %s/%s/%s', user, repo_name, number)
     except BaseException as e:
         log.exception(e)
+    finally:
+        try:
+            git.destroy(target_path)
+            log.info('Cleaned up pull request %s/%s/%s',
+                     user, repo_name, number)
+        except BaseException as e:
+            log.exception(e)
 
 
 @celery.task(ignore_result=True)


### PR DESCRIPTION
This is a little ugly, but I don't know if it would be a lot better to refactor using nested functions, which could be ugly __and__ hard to follow.

The problem I'd like to address is when an uncaught exception occurs while processing a PR, the workspace is left in place and human intervention is required to get the PR un-stuck. I've observed failures occur due to things like bad linter tool configs, our internal GitHub Enterprise instance flaking out, etc.