### PR TITLE
Limit worker concurrency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       - worker
       - -l
       - info
+      - --concurrency
+      - '1'
     healthcheck:
       test: ["CMD", "/code/docker_healthcheck.sh", "worker"]
       interval: 10s


### PR DESCRIPTION
Having more than one worker can cause issues in cases where more than
one job is running for a given PR.

Relates to #202 