### PR TITLE
Enable eslint to install plugins on demand

### DIFF
--- a/docker/eslint-install.sh
+++ b/docker/eslint-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check for /src/package.json if it doesn't exist exit.
+if [ ! -e /src/package.json  ]; then
+	exit 0
+fi
+
+cd /tool || exit 1
+
+# Use grep & awk to find eslint packages.
+while read -r package
+do
+	# Clean up the JSON into something we can put into npm install.
+	package_name=$(echo "$package" | sed -e 's/,//' | sed -e 's/"//g' | sed -e 's/://' | awk '{print $1 "@" $2}')
+
+	# Install required plugins into /tool/node_modules
+	npm install "$package_name"
+done <  <(grep -i -E 'eslint-[plugin|config]-*' /src/package.json)

--- a/docker/nodejs.Dockerfile
+++ b/docker/nodejs.Dockerfile
@@ -1,9 +1,14 @@
 FROM node:8-alpine
 
 RUN mkdir /src \
-  && mkdir /tool
+  && mkdir /tool \
+  && apk --update add bash \
+  # Upgrade npm to get around pruning issues.
+  && npm install npm@latest -g \
+  && rm -rf /var/cache/apk/*
 
 COPY package.json /tool
+COPY eslint-install.sh /usr/bin/eslint-install
 
 # Install node tools
 RUN cd /tool \
@@ -19,6 +24,7 @@ RUN cd /tool \
   && ln -s /tool/node_modules/.bin/xo /usr/bin/xo \
   # Move package.json so that it is an ancestor of /src allowing
   # eslint and xo to use it for config
-  && mv /tool/package.json /
+  && cp /tool/package.json / \
+  && chmod +x /usr/bin/eslint-install
 
 WORKDIR /src

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -67,6 +67,21 @@ def images():
     return output
 
 
+def containers(include_stopped=False):
+    """Get the container list"""
+    cmd = ['docker', 'ps', '--format', '{{.Names}}']
+    if include_stopped:
+        cmd += ['-a']
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False)
+    output, error = process.communicate()
+    return output
+
+
 def run(image, command, source_dir, env=None, timeout=None, name=None):
     """Execute tool commands in docker containers.
 

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -64,7 +64,7 @@ def images():
         stderr=subprocess.PIPE,
         shell=False)
     output, error = process.communicate()
-    return output
+    return output.decode('utf8')
 
 
 def containers(include_stopped=False):
@@ -79,7 +79,7 @@ def containers(include_stopped=False):
         stderr=subprocess.PIPE,
         shell=False)
     output, error = process.communicate()
-    return output
+    return output.decode('utf8')
 
 
 def run(image, command, source_dir, env=None, timeout=None, name=None):

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import logging
 import subprocess
-from six.moves import map
 import six
 import os
 
@@ -56,7 +55,19 @@ def image_exists(name):
     return len(output) > 0
 
 
-def run(image, command, source_dir, env=None, timeout=None):
+def images():
+    """Get the docker image list"""
+    process = subprocess.Popen(
+        ['docker', 'images'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False)
+    output, error = process.communicate()
+    return output
+
+
+def run(image, command, source_dir, env=None, timeout=None, name=None):
     """Execute tool commands in docker containers.
 
     All output from the container will be treated as tool output
@@ -74,10 +85,16 @@ def run(image, command, source_dir, env=None, timeout=None):
     elif env:
         raise ValueError('env argument should be a dict')
 
-    # TODO add timeout support
-    cmd = [
-        'docker', 'run', '--rm',
-        '-v', u'{}:{}'.format(source_dir, DOCKER_BASE)
+    cmd = ['docker', 'run']
+
+    if name is not None:
+        cmd += ['--name', name]
+    else:
+        cmd.append('--rm')
+
+    cmd += [
+        '-v',
+        u'{}:{}'.format(source_dir, DOCKER_BASE)
     ]
     cmd += env_args
     cmd.append(image)
@@ -86,7 +103,7 @@ def run(image, command, source_dir, env=None, timeout=None):
     # to get around encoding issues.
     cmd += [six.text_type(arg).encode('utf8') for arg in command]
 
-    log.debug(u'Running {}'.format(cmd))
+    log.debug('Running %s', cmd)
     process = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
@@ -103,3 +120,64 @@ def run(image, command, source_dir, env=None, timeout=None):
     if isinstance(output, six.binary_type):
         return output.decode('utf8')
     return output
+
+
+def rm_container(name):
+    """
+    Remove a container with the provided name
+    """
+    cmd = ['docker', 'rm', name]
+
+    log.debug('Running %s', cmd)
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True)
+
+    # Get output bytes/string
+    output, error = process.communicate()
+    output = error + output
+    if process.returncode != 0:
+        raise ValueError(output)
+
+
+def rm_image(name):
+    """
+    Remove the named image with the provided name
+    """
+    cmd = ['docker', 'rmi', name]
+    log.debug('Running %s', cmd)
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True)
+
+    # Get output bytes/string
+    output, error = process.communicate()
+    output = error + output
+    if process.returncode != 0:
+        raise ValueError(output)
+
+
+def commit(name):
+    """Commit a container state into a new image
+    """
+    cmd = ['docker', 'commit', name, name]
+    log.debug('Running %s', cmd)
+
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True)
+
+    # Get output bytes/string
+    output, error = process.communicate()
+    output = error + output
+    if process.returncode != 0:
+        raise ValueError(output)

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -110,7 +110,7 @@ class Eslint(Tool):
             return None
 
         m = hashlib.md5()
-        m.update('-'.join(files))
+        m.update('-'.join(files).encode('utf8'))
         return 'eslint-' + m.hexdigest()
 
     def _cleanup(self, container_name):

--- a/tests/fixtures/eslint_custom/config.json
+++ b/tests/fixtures/eslint_custom/config.json
@@ -1,0 +1,6 @@
+{
+    "extends": "airbnb-base",
+    "env": {
+        "browser": true
+    }
+}

--- a/tests/fixtures/eslint_custom/fixer_errors.js
+++ b/tests/fixtures/eslint_custom/fixer_errors.js
@@ -1,0 +1,6 @@
+function thing(b,c)
+{
+return 1+2+b+c;;;;
+}
+
+thing(4, 5);

--- a/tests/fixtures/eslint_custom/has_errors.js
+++ b/tests/fixtures/eslint_custom/has_errors.js
@@ -1,0 +1,4 @@
+// no semicolon, bar is not defined, foo is never used
+var foo = bar
+// alert is only defined in the 'browser' environment
+alert("oh noes");

--- a/tests/fixtures/eslint_custom/invalid.json
+++ b/tests/fixtures/eslint_custom/invalid.json
@@ -1,0 +1,3 @@
+{
+    "extends": "invalid-rules"
+}

--- a/tests/fixtures/eslint_custom/package.json
+++ b/tests/fixtures/eslint_custom/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lintreview-custom-eslint",
+  "version": "0.0.1",
+  "dependencies": {
+    "eslint-config-airbnb-base": "latest"
+  }
+}

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import lintreview.docker as docker
-from nose.tools import eq_
+from nose.tools import eq_, ok_, assert_in
 from tests import requires_image, test_dir
 
 
@@ -31,3 +31,21 @@ def test_run__unicode():
     cmd = ['echo', u"\u2620"]
     output = docker.run('python2', cmd, test_dir)
     eq_(output, u"\u2620\n")
+
+
+@requires_image('python2')
+def test_run__named_container():
+    cmd = ['echo', "things"]
+    docker.run('python2', cmd, test_dir, name='test_container')
+    containers = docker.containers(include_stopped=True)
+    assert_in('test_container', containers)
+    docker.rm_container('test_container')
+
+    containers = docker.containers(include_stopped=True)
+    assert 'test_conainer' not in containers
+
+
+@requires_image('python2')
+def test_images():
+    result = docker.images()
+    assert_in('python2', result)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import lintreview.docker as docker
-from nose.tools import eq_, ok_, assert_in
+from nose.tools import eq_, assert_in
 from tests import requires_image, test_dir
 
 


### PR DESCRIPTION
Enable the eslint tool to install plugins as needed when reviewing repositories. This makes it simpler to operate lintreview when dealing with repositories that require different and possibly conflicting eslint plugins.