### PR TITLE
Add some default properties to Checkstyle

### DIFF
--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -213,6 +213,9 @@ def process_checkstyle(problems, xml, filename_converter):
         # Some tools return "" if no errors are found
         return
     try:
+        # Needed for Python 2.7; http://bugs.python.org/issue11033
+        if isinstance(xml, six.text_type):
+            xml = xml.encode('utf-8')
         tree = ElementTree.fromstring(xml)
     except:
         log.error("Unable to parse XML %s", xml)

--- a/lintreview/tools/checkstyle.py
+++ b/lintreview/tools/checkstyle.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import six
 from tempfile import NamedTemporaryFile
 import lintreview.docker as docker
 from lintreview.review import IssueComment
@@ -81,6 +82,8 @@ class Checkstyle(Tool):
             ord(u"\r"): u"\\r",
         }
 
+        if not isinstance(value, six.text_type):
+            value = value.decode('utf-8')
         value = value.translate(replacements)
 
         def escape_unicode(match):
@@ -107,8 +110,9 @@ class Checkstyle(Tool):
         }
 
         for key, value in properties.items():
-            properties_file.write(b'%b=%b\n' % (
-                self.escape_for_java(key), self.escape_for_java(value)))
+            line = u'{0}={1}\n'.format(
+                self.escape_for_java(key), self.escape_for_java(value))
+            properties_file.write(line.encode('utf-8'))
         properties_file.flush()
 
     def create_command(self, properties_filename, files):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ github3.py==1.0.0a4
 celery==3.1.23
 gunicorn==0.17.2
 argparse>=1.2.0,<=1.3.0
+jprops==2.0.2

--- a/tests/fixtures/checkstyle/沒有錯誤.java
+++ b/tests/fixtures/checkstyle/沒有錯誤.java
@@ -1,0 +1,19 @@
+/**
+ * Comment.
+ */
+public final class HelloWorld {
+    /**
+     * Comment.
+     */
+    private constructor() {
+    }
+
+    /**
+     * Comment.
+     *
+     * @param args Things
+     */
+    public static void main(final String[] args) {
+        System.out.println("Hello, World");
+    }
+}

--- a/tests/tools/test_checkstyle.py
+++ b/tests/tools/test_checkstyle.py
@@ -11,6 +11,7 @@ class TestCheckstyle(TestCase):
     fixtures = [
         'tests/fixtures/checkstyle/no_errors.java',
         'tests/fixtures/checkstyle/has_errors.java',
+        'tests/fixtures/checkstyle/沒有錯誤.java',
     ]
 
     def setUp(self):
@@ -96,10 +97,11 @@ class TestCheckstyle(TestCase):
             'config': 'test/checkstyle.xml'
         }
         tool = Checkstyle(self.problems, config, root_dir)
-        result = tool.create_command(['some/file.js'])
+        result = tool.create_command('tmp1.properties', ['some/file.js'])
         expected = [
             'checkstyle',
             '-f', 'xml',
+            '-p', '/src/tmp1.properties',
             '-c', '/src/test/checkstyle.xml',
             'some/file.js'
         ]

--- a/tests/tools/test_checkstyle.py
+++ b/tests/tools/test_checkstyle.py
@@ -11,7 +11,7 @@ class TestCheckstyle(TestCase):
     fixtures = [
         'tests/fixtures/checkstyle/no_errors.java',
         'tests/fixtures/checkstyle/has_errors.java',
-        'tests/fixtures/checkstyle/沒有錯誤.java',
+        u'tests/fixtures/checkstyle/\u6c92\u6709\u932f\u8aa4.java',
     ]
 
     def setUp(self):


### PR DESCRIPTION
Eclipse and IntelliJ Checkstyle plugins define some default properties
that you can use in your checkstyle.xml. This will mirror those pre-set
properties and allow you to use configurations that work in your IDE.