### PR TITLE
No need for explicit matrix statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ python:
   - "2.7"
   - "3.6"
 
-matrix:
-  include:
-    - python: "2.7"
-    - python: "3.6"
-
 env:
   - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"
 


### PR DESCRIPTION
There is already a matrix created implicitly by setting multiple Python
versions. When the matrix element is included, it creates another set of
rows resulting in a 2x2 matrix with only 2 real distinct configurations.