### PR TITLE
Fix yamllint fatal errors.

### DIFF
--- a/lintreview/tools/yamllint.py
+++ b/lintreview/tools/yamllint.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import os
 import logging
 import lintreview.docker as docker
+from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix
 
 log = logging.getLogger(__name__)
@@ -44,6 +45,14 @@ class Yamllint(Tool):
         if not output:
             log.debug('No yamllint errors found.')
             return False
+
+        if 'No such file' in output and 'Traceback' in output:
+            error = output.strip().split("\n")[-1]
+            msg = (u'`yamllint` failed with the following error:\n'
+                   '```\n'
+                   '{}\n'
+                   '```\n')
+            return self.problems.add(IssueComment(msg.format(error)))
 
         output = output.split("\n")
         process_quickfix(self.problems, output, docker.strip_base)

--- a/tests/tools/test_yamllint.py
+++ b/tests/tools/test_yamllint.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.yamllint import Yamllint
 from unittest import TestCase
-from nose.tools import eq_
+from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -69,7 +69,7 @@ class TestYamllint(TestCase):
         eq_(expected, problems[1])
 
     @requires_image('python2')
-    def test_process_files_with_config(self):
+    def test_process_files__config(self):
         config = {
             'config': 'tests/fixtures/yamllint/config.yaml'
         }
@@ -80,3 +80,21 @@ class TestYamllint(TestCase):
 
         eq_(1, len(problems),
             'Config file should cause errors on no_errors.yml')
+
+    @requires_image('python2')
+    def test_process_files__missing_config(self):
+        config = {
+            'config': 'tests/fixtures/yamllint/lol.yaml'
+        }
+        tool = Yamllint(self.problems, config, root_dir)
+        tool.process_files([self.fixtures[0]])
+
+        problems = self.problems.all()
+
+        eq_(1, len(problems))
+        assert_in(
+            '`yamllint` failed with the following error:\n'
+            '```\n'
+            "IOError: [Errno 2] No such file or directory: '/src/tests/fixtures/yamllint/lol.yaml'\n"
+            '```\n',
+            problems[0].body)


### PR DESCRIPTION
Add a more useful error when the requested yamllint config file doesn't exist.