### PR TITLE
Remove --isolated from flake8 tool

### DIFF
--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -67,7 +67,10 @@ class Flake8(Tool):
                     '--%s' % option,
                     self.options.get(option)
                 ])
-
+        if 'config' in self.options:
+            command.extend(['--format', 'default'])
+        else:
+            command.append('--isolated')
         command += files
         return command
 

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -60,7 +60,7 @@ class Flake8(Tool):
         process_quickfix(self.problems, output, docker.strip_base)
 
     def make_command(self, files):
-        command = ['flake8', '--isolated']
+        command = ['flake8']
         for option in self.options:
             if option in self.PYFLAKE_OPTIONS:
                 command.extend([

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -103,7 +103,6 @@ class TestFlake8(TestCase):
         out = tool.make_command([self.fixtures[1]])
         expected = [
             'flake8',
-            '--isolated',
             '--ignore', 'F4,W603',
             '--max-complexity', 10,
             '--max-line-length', 120,

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -93,7 +93,7 @@ class TestFlake8(TestCase):
             self.assertFalse('F4' in p.body)
             self.assertFalse('W603' in p.body)
 
-    def test_make_command__config(self):
+    def test_make_command__no_config(self):
         options = {
             'ignore': 'F4,W603',
             'max-line-length': 120,
@@ -106,6 +106,27 @@ class TestFlake8(TestCase):
             '--ignore', 'F4,W603',
             '--max-complexity', 10,
             '--max-line-length', 120,
+            '--isolated',
+            self.fixtures[1]
+        ]
+        eq_(set(expected), set(out))
+
+    def test_make_command__config(self):
+        options = {
+            'ignore': 'F4,W603',
+            'max-line-length': 120,
+            'max-complexity': 10,
+            'config': '.flake8'
+        }
+        tool = Flake8(self.problems, options, root_dir)
+        out = tool.make_command([self.fixtures[1]])
+        expected = [
+            'flake8',
+            '--ignore', 'F4,W603',
+            '--max-complexity', 10,
+            '--max-line-length', 120,
+            '--config', '.flake8',
+            '--format', 'default',
             self.fixtures[1]
         ]
         eq_(set(expected), set(out))


### PR DESCRIPTION
Context: #221 

According to `flake8 --help`, looks like `--config` already ignores configs other than the one provided, so `--isolated` is redundant.
```
  --config=CONFIG       Path to the config file that will be the authoritative
                        config source. This will cause Flake8 to ignore all
                        other configuration files.
  --isolated            Ignore all found configuration files.
```

Additionally, the `--isolated` flag ignores *all* configs, not just found ones, so it renders the config file passed with `--config` useless.

https://github.com/PyCQA/flake8/blob/master/src/flake8/options/config.py#L295-L306