### PR TITLE
Use compact csslint output.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,6 @@
 linters:
-  flake8: {  }
+  flake8:
+    max-line-length: 100
   rubocop: {  }
 ignore:
   files:

--- a/tests/tools/test_csslint.py
+++ b/tests/tools/test_csslint.py
@@ -40,11 +40,11 @@ class TestCsslint(TestCase):
         eq_(2, len(problems))
 
         fname = self.fixtures[1]
-        expected = Comment(fname, 1, 1, "Don't use IDs in selectors.")
+        expected = Comment(fname, 1, 1, "Warning - Don't use IDs in selectors.")
         eq_(expected, problems[0])
 
         expected = Comment(fname, 2, 2,
-                           "Using width with padding can"
+                           "Warning - Using width with padding can"
                            " sometimes make elements larger than you expect.")
         eq_(expected, problems[1])
 


### PR DESCRIPTION
I've been having some bad output from csslint when the checkstyle file is used. Try this output format to see if it is less problematic than checkstyle is.