### PR TITLE
Checks API

### DIFF
--- a/lintreview/config.py
+++ b/lintreview/config.py
@@ -122,37 +122,37 @@ class ReviewConfig(object):
     def linters(self):
         try:
             return list(self._data['linters'].keys())
-        except:
+        except Exception:
             return []
 
     def linter_config(self, tool):
         try:
             return self._data['linters'][tool]
-        except:
+        except Exception:
             return {}
 
     def fixers_enabled(self):
         try:
             return bool(self._data['fixers']['enable'])
-        except:
+        except Exception:
             return False
 
     def fixer_workflow(self):
         try:
             return self._data['fixers']['workflow']
-        except:
+        except Exception:
             return 'commit'
 
     def ignore_patterns(self):
         try:
             return self._data['files']['ignore']
-        except:
+        except Exception:
             return []
 
     def ignore_branches(self):
         try:
             return self._data['branches']['ignore']
-        except:
+        except Exception:
             return []
 
     def summary_threshold(self):
@@ -161,11 +161,11 @@ class ReviewConfig(object):
         if 'review' in self._data:
             try:
                 return int(self._data['review']['summary_comment_threshold'])
-            except:
+            except Exception:
                 pass
         try:
             return int(self._data['SUMMARY_THRESHOLD'])
-        except:
+        except Exception:
             return None
 
     def passed_review_label(self):
@@ -174,11 +174,11 @@ class ReviewConfig(object):
         if 'review' in self._data:
             try:
                 return self._data['review']['apply_label_on_pass']
-            except:
+            except KeyError:
                 pass
         try:
             return self._data['OK_LABEL']
-        except:
+        except KeyError:
             return None
 
     def failed_review_status(self):
@@ -189,12 +189,23 @@ class ReviewConfig(object):
                 value = boolean_value(self._data['review']['fail_on_comments'])
 
                 return 'failure' if value else 'success'
-            except:
+            except Exception:
                 pass
         if 'PULLREQUEST_STATUS' in self._data:
             value = boolean_value(self._data['PULLREQUEST_STATUS'])
             return 'failure' if value else 'success'
         return 'failure'
+
+    def use_checks(self):
+        """Should review results be submitted via the Checks API
+
+        This assumes that lintreview is being run as a GitHub app integration
+        and not an Oauth integration.
+        """
+        try:
+            return boolean_value(self._data['review']['use_checks'])
+        except KeyError:
+            return False
 
     def get(self, key, default=None):
         """Dict compatibility accessor for application config data

--- a/lintreview/repo.py
+++ b/lintreview/repo.py
@@ -150,3 +150,9 @@ class GithubPullRequest(object):
 
     def create_review_comment(self, body, commit_id, path, position):
         self.pull.create_review_comment(body, commit_id, path, position)
+
+    def create_checkrun(self, review):
+        url = self.pull._build_url('check-runs', base_url=self.pull._api)
+        # TODO add special header
+        self.pull._json(self.pull._post(url, data=review), 201)
+

--- a/lintreview/repo.py
+++ b/lintreview/repo.py
@@ -151,8 +151,11 @@ class GithubPullRequest(object):
     def create_review_comment(self, body, commit_id, path, position):
         self.pull.create_review_comment(body, commit_id, path, position)
 
-    def create_checkrun(self, review):
+    def create_checkrun(self, checkrun):
         url = self.pull._build_url('check-runs', base_url=self.pull._api)
-        # TODO add special header
-        self.pull._json(self.pull._post(url, data=review), 201)
+        headers = {
+            'Accept': 'application/vnd.github.antiope-preview+json'
+        }
+        res = self.pull._post(url, data=checkrun, headers=headers)
+        self.pull._json(res, 201)
 

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -150,6 +150,9 @@ class Review(object):
         under_threshold = (threshold is None or
                            new_problem_count < threshold)
 
+        if self.config.use_checks():
+            return self.publish_checks(problems, head_sha)
+
         if under_threshold:
             self.publish_review(problems, head_sha)
         else:
@@ -225,6 +228,25 @@ class Review(object):
             'comments': comments
         }
         return review
+
+    def publish_checkrun(self, problems, head_commit):
+        """Publish the issues contained in the problems
+        parameter. Changes is used to fetch the commit sha
+        for the comments on a given file.
+        """
+        log.info("Publishing checkrun of %s new comments for %s",
+                 len(problems),
+                 self._pr.display_name)
+        self.remove_ok_label()
+        review = self._build_checkrun(problems, head_commit)
+        if len(review['output']):
+            self._pr.create_checkrun(review)
+
+    def _build_checkrun(self, problems, head_commit):
+        """Because github3.py doesn't support creating checkruns
+        we use some workarounds.
+        """
+        pass
 
     def publish_status(self, problem_count):
         """Update the build status for the tip commit.

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -13,7 +13,7 @@ class IssueLabel(object):
     def remove(self, pull_request):
         try:
             pull_request.remove_label(self.label)
-        except:
+        except Exception:
             log.warn("Failed to remove label '%s'", self.label)
 
     def publish(self, repo, pull_request):
@@ -22,7 +22,7 @@ class IssueLabel(object):
         try:
             repo.ensure_label(self.label)
             pull_request.add_label(self.label)
-        except:
+        except Exception:
             log.warn("Failed to add label '%s'", self.label)
 
 

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from collections import OrderedDict
+from datetime import datetime
 import logging
 
 log = logging.getLogger(__name__)
@@ -86,14 +87,29 @@ class Comment(BaseComment):
         self.body = body
         self.line = line
         self.filename = filename
-        self.position = position
+        self.position = position or 0
 
     def payload(self):
+        """Generate payload for comment based reviews"""
         return {
             'path': self.filename,
             'position': self.position,
             'body': self.body,
         }
+
+    def checkrun_payload(self):
+        """Generate payload for checks based review."""
+        payload = {
+            'path': self.filename,
+            'start_line': self.line,
+            'end_line': self.line,
+            # TODO extract this data for linters that support it
+            'start_column': 1,
+            'message': self.body,
+            # TODO extract this data for linters that support it
+            'annotation_level': 'failure',
+        }
+        return payload
 
     def key(self):
         return (self.filename, self.position)
@@ -136,12 +152,27 @@ class Review(object):
         Existing comments are loaded, and compared
         to new problems. Once the new unique problems
         are distilled new comments are published.
+
+        TODO consider extracting publishing from the
+        review and making checks/comment based publishers.
         """
+        has_problems = len(problems) > 0
+
+        if self.config.use_checks():
+            self.publish_checkrun(problems, has_problems, head_sha)
+            # TODO need to find out if the check status +
+            # build status share the same 'namespace'
+            self.publish_status(has_problems)
+            return
+
+        # If the pull request has no changes notify why
+        # We didn't review the changes.
         if not problems.has_changes():
             return self.publish_empty_comment()
 
+        # If we are submitting a comment review
+        # we drop comments that have already been posted.
         self.load_comments()
-        total_problem_count = len(problems)
         self.remove_existing(problems)
 
         new_problem_count = len(problems)
@@ -150,14 +181,11 @@ class Review(object):
         under_threshold = (threshold is None or
                            new_problem_count < threshold)
 
-        if self.config.use_checks():
-            return self.publish_checks(problems, head_sha)
-
         if under_threshold:
             self.publish_review(problems, head_sha)
         else:
             self.publish_summary(problems)
-        self.publish_status(total_problem_count)
+        self.publish_status(has_problems)
 
     def load_comments(self):
         """Load the existing comments on a pull request
@@ -229,7 +257,7 @@ class Review(object):
         }
         return review
 
-    def publish_checkrun(self, problems, head_commit):
+    def publish_checkrun(self, problems, has_problems, head_commit):
         """Publish the issues contained in the problems
         parameter. Changes is used to fetch the commit sha
         for the comments on a given file.
@@ -238,23 +266,47 @@ class Review(object):
                  len(problems),
                  self._pr.display_name)
         self.remove_ok_label()
-        review = self._build_checkrun(problems, head_commit)
+        review = self._build_checkrun(problems, has_problems, head_commit)
         if len(review['output']):
             self._pr.create_checkrun(review)
 
-    def _build_checkrun(self, problems, head_commit):
+    def _build_checkrun(self, problems, has_problems, head_commit):
         """Because github3.py doesn't support creating checkruns
         we use some workarounds.
         """
-        pass
+        body = [
+            comment.body
+            for comment in problems
+            if isinstance(comment, IssueComment)
+        ]
+        comments = [
+            comment.checkrun_payload()
+            for comment in problems
+            if isinstance(comment, Comment)
+        ]
+        conclusion = 'failure' if has_problems else 'success'
+        output = {
+            'title': 'Style Check Result',
+            'summary': "\n".join(body),
+            'annotations': comments
+        }
 
-    def publish_status(self, problem_count):
+        run = {
+            'head_sha': head_commit,
+            'name': self.config.get('APP_NAME', 'lintreview'),
+            'conclusion': conclusion,
+            'completed_at': datetime.utcnow().isoformat(),
+            'output': output,
+        }
+        return run
+
+    def publish_status(self, has_problems):
         """Update the build status for the tip commit.
         The build will be a success if there are 0 problems.
         """
         state = self.config.failed_review_status()
         description = 'Lint errors found, see pull request comments.'
-        if problem_count == 0:
+        if not has_problems:
             self.publish_ok_label()
             self.publish_ok_comment()
             state = 'success'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,3 +79,18 @@ fixer = true
 [fixers]
 enable = true
 """
+
+
+checks_ini = """
+[tools]
+linters = phpcs, eslint
+
+[tool_phpcs]
+fixer = true
+
+[fixers]
+enable = true
+
+[review]
+use_checks = true
+"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,7 @@ review_ini = """
 linters = jshint
 
 [review]
+use_checks = True
 summary_comment_threshold = 25
 fail_on_comments = False
 apply_label_on_pass = lint ok
@@ -222,3 +223,10 @@ class ReviewConfigTest(TestCase):
         ini = "[review]\nfail_on_comments = true"
         config = build_review_config(ini, app_config)
         eq_('failure', config.failed_review_status())
+
+    def test_use_checks(self):
+        config = build_review_config(review_ini, app_config)
+        assert config.use_checks()
+
+        config = build_review_config(sample_ini, app_config)
+        assert config.use_checks() is False

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -179,6 +179,26 @@ class TestGithubPullRequest(TestCase):
             data=review)
         assert self.model._json.called
 
+    def test_create_checkrun(self):
+        self.model._post = Mock()
+        self.model._json = Mock()
+        pull = GithubPullRequest(self.model)
+        review = {
+            'commit_sha': 'abc123',
+            'conclusion': 'success',
+            'output': {
+                'title': 'Style Review',
+                'summary': '',
+                'annotations': [],
+            }
+        }
+        pull.create_checkrun(review)
+        self.model._post.assert_called_with(
+            'https://api.github.com/repos/markstory/lint-test/pulls/1/check-runs',
+            data=review,
+            headers={'Accept': 'application/vnd.github.antiope-preview+json'})
+        assert self.model._json.called
+
     def test_maintainer_can_modify__same_repo(self):
         pull = GithubPullRequest(self.model)
         eq_(True, pull.maintainer_can_modify)


### PR DESCRIPTION
This is a first draft of the checks API support. Checks require using a GitHub integration which is not possible with the self-hosted version of lintreview but is available on stickler-ci.com.