### PR TITLE
Separate publish modes.

### DIFF
--- a/lintreview/config.py
+++ b/lintreview/config.py
@@ -196,17 +196,6 @@ class ReviewConfig(object):
             return 'failure' if value else 'success'
         return 'failure'
 
-    def use_checks(self):
-        """Should review results be submitted via the Checks API
-
-        This assumes that lintreview is being run as a GitHub app integration
-        and not an Oauth integration.
-        """
-        try:
-            return boolean_value(self._data['review']['use_checks'])
-        except KeyError:
-            return False
-
     def get(self, key, default=None):
         """Dict compatibility accessor for application config data
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,18 +79,3 @@ fixer = true
 [fixers]
 enable = true
 """
-
-
-checks_ini = """
-[tools]
-linters = phpcs, eslint
-
-[tool_phpcs]
-fixer = true
-
-[fixers]
-enable = true
-
-[review]
-use_checks = true
-"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,6 @@ review_ini = """
 linters = jshint
 
 [review]
-use_checks = True
 summary_comment_threshold = 25
 fail_on_comments = False
 apply_label_on_pass = lint ok
@@ -223,10 +222,3 @@ class ReviewConfigTest(TestCase):
         ini = "[review]\nfail_on_comments = true"
         config = build_review_config(ini, app_config)
         eq_('failure', config.failed_review_status())
-
-    def test_use_checks(self):
-        config = build_review_config(review_ini, app_config)
-        assert config.use_checks()
-
-        config = build_review_config(sample_ini, app_config)
-        assert config.use_checks() is False

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -80,7 +80,6 @@ class TestGithubRepository(TestCase):
         model = self.repo_model
         model._post = Mock()
         model._json = Mock()
-        import pdb; pdb.set_trace()
 
         repo = GithubRepository(config, 'markstory', 'lint-test')
         repo.repository = lambda: model


### PR DESCRIPTION
Deciding to use checks based on the config file is not going to work as well as I had hoped. Checks require all status progression operations to be done on the checkrun. Using statuses + checks creates duplicate state in github.