### PR TITLE
Fix consistency error

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -211,9 +211,10 @@ class Review(object):
         # If we are submitting a comment review
         # we drop comments that have already been posted.
         self.load_comments()
-        self.remove_existing(problems)
 
         has_problems = len(problems) > 0
+
+        self.remove_existing(problems)
         new_problem_count = len(problems)
 
         threshold = self.config.summary_threshold()

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -215,6 +215,7 @@ class Review(object):
         has_problems = len(problems) > 0
 
         self.remove_existing(problems)
+
         new_problem_count = len(problems)
 
         threshold = self.config.summary_threshold()


### PR DESCRIPTION
Pushing a change to a branch that doesn't resolve some/all of the lint errors results in a green OK instead of a Red "Failed". I believe it's because we remove existing problems from the Problem object before we determine if it has problems or not. So if the number is the same, `has_problems` is False.