### PR TITLE
Ensure properties file has been written before using it

### DIFF
--- a/tests/tools/test_checkstyle.py
+++ b/tests/tools/test_checkstyle.py
@@ -84,7 +84,7 @@ class TestCheckstyle(TestCase):
     @requires_image('checkstyle')
     def test_process_files__missing_config(self):
         config = {'config': 'badness.xml'}
-        tool = Checkstyle(self.problems, config)
+        tool = Checkstyle(self.problems, config, root_dir)
         tool.process_files(self.fixtures)
 
         problems = self.problems.all()


### PR DESCRIPTION
Close the properties file before trying to read it. This ensures that the file has been written to disk.