### PR TITLE
Don't log warnings when fixer application fails.

### DIFF
--- a/lintreview/fixers/commit_strategy.py
+++ b/lintreview/fixers/commit_strategy.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from lintreview.fixers.error import WorkflowError
 import lintreview.git as git
 import logging
+import six
 
 log = logging.getLogger(__name__)
 
@@ -37,4 +38,14 @@ class CommitStrategy(object):
         remote_branch = self.pull_request.head_branch
 
         git.commit(self.path, author, 'Fixing style errors.')
-        git.push(self.path, 'origin', u'stylefixes:{}'.format(remote_branch))
+        try:
+            git.push(self.path, 'origin', u'stylefixes:{}'.format(remote_branch))
+        except IOError as err:
+            message = six.text_type(err)
+            log.debug(message)
+            if '(permission denied)' in message:
+                raise WorkflowError('Could not push fix commit because permission was denied')
+            if '[remote rejected]' in message:
+                raise WorkflowError('Could not push fix commit because it was not a fast-forward')
+            raise err
+

--- a/lintreview/fixers/commit_strategy.py
+++ b/lintreview/fixers/commit_strategy.py
@@ -48,4 +48,3 @@ class CommitStrategy(object):
             if '[remote rejected]' in message:
                 raise WorkflowError('Could not push fix commit because it was not a fast-forward')
             raise err
-

--- a/lintreview/git.py
+++ b/lintreview/git.py
@@ -172,9 +172,12 @@ def branch_exists(path, name):
     return len(matching) == 1
 
 
-@log_io_error
 def push(path, remote, branch):
     """Push a branch to the named remote
+
+    This method does not use the `log_io_error` decorator
+    because the caller should handle what happens when a
+    push fails.
     """
     command = ['git', 'push', remote, branch]
     return_code, output = _process(command, chdir=path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ celery==3.1.23
 gunicorn==19.5.0
 argparse>=1.2.0,<=1.3.0
 jprops==2.0.2
+six>=1.11.0,<1.12.0

--- a/tests/fixers/test_commit_strategy.py
+++ b/tests/fixers/test_commit_strategy.py
@@ -6,7 +6,6 @@ from nose.tools import assert_in, assert_raises, with_setup, eq_
 from ..test_git import setup_repo, teardown_repo, clone_path
 
 
-
 def test_init_key_requirements():
     keys = ('repo_path', 'author_email', 'author_name',
             'pull_request')
@@ -17,6 +16,7 @@ def test_init_key_requirements():
         del context[key]
         with assert_raises(KeyError):
             CommitStrategy(context)
+
 
 @with_setup(setup_repo, teardown_repo)
 @patch('lintreview.git.commit')

--- a/tests/fixers/test_commit_strategy.py
+++ b/tests/fixers/test_commit_strategy.py
@@ -6,6 +6,7 @@ from nose.tools import assert_in, assert_raises, with_setup, eq_
 from ..test_git import setup_repo, teardown_repo, clone_path
 
 
+
 def test_init_key_requirements():
     keys = ('repo_path', 'author_email', 'author_name',
             'pull_request')
@@ -16,6 +17,31 @@ def test_init_key_requirements():
         del context[key]
         with assert_raises(KeyError):
             CommitStrategy(context)
+
+@with_setup(setup_repo, teardown_repo)
+@patch('lintreview.git.commit')
+@patch('lintreview.git.push')
+@patch('lintreview.git.apply_cached')
+def test_execute__push_error(mock_apply, mock_push, mock_commit):
+    mock_push.side_effect = IOError(
+            '! [remote rejected] stylefixes -> add_date_to_obs (permission denied)'
+            '\nerror: failed to push some refs to')
+    mock_pull = Mock(
+        head_branch='patch-1',
+        from_private_fork=False,
+        maintainer_can_modify=True)
+    context = {
+        'repo_path': clone_path,
+        'author_name': 'lintbot',
+        'author_email': 'lint@example.com',
+        'pull_request': mock_pull
+    }
+    strategy = CommitStrategy(context)
+
+    diff = Mock()
+    diff.as_diff.return_value = sentinel.diff
+    with assert_raises(WorkflowError):
+        strategy.execute([diff])
 
 
 @with_setup(setup_repo, teardown_repo)


### PR DESCRIPTION
Not being able to push changes to because of permission errors or non-fast-forward pushes is not an error level event. Pulls could come from contributors who don't allow github app access, or have had changes applied since the review was queued/cloned.