### PR TITLE
Move from nosetests to Pytest

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -1,2 +1,5 @@
 [tools]
 linters = flake8, jsonlint, yamllint
+
+[tool_flake8]
+exclude = has_errors.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
 
 before_install:
   - make images
+  - docker pull markstory/swiftlint
+  - docker tag markstory/swiftlint swiftlint
 
 install:
   - pip install -r requirements-dev.txt
@@ -28,7 +30,9 @@ install:
   - cp settings.sample.py settings.py
 
 script:
-  - nosetests --with-coverage --cover-package lintreview
+  - >
+    pytest -p no:cacheprovider \
+      --cov=lintreview
 
 after_success:
   - codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+# This allows us to cache the pip install stage
+ADD requirements.txt /
+RUN pip install -r /requirements.txt
+
 ADD . /code
-ADD requirements.txt /code/
-RUN cd /code && pip install -r requirements.txt
-RUN cd /code && pip install .
+RUN pip install -e .
 RUN cp /code/settings.sample.py /code/settings.py

--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -3,6 +3,9 @@ git config --global user.name dockerbot
 git config --global user.email dockerbot@example.com
 
 pip install -r requirements-dev.txt
-pip install codecov coverage
 
-nosetests --with-coverage --cover-package lintreview
+pytest \
+    -p no:cacheprovider \
+    --cov=lintreview \
+    --cov-report=xml:/data/results/coverage.xml \
+    --junitxml=/data/results/nosetests.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-nose>=1.2.1,<2.0.0
-mock>=1.0.1,<2.0.0
+pytest~=4.3
+pytest-cov~=2.6
+mock~=2.0
 codecov
 coverage

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,16 +1,22 @@
 from __future__ import absolute_import
 import os
 import json
+import tempfile
+from unittest import skipIf
+from mock import patch
+
 import lintreview.git as git
 import lintreview.docker as docker
 from github3.pulls import PullFile
 from github3.repos.commit import ShortCommit
 from github3.session import GitHubSession
-from unittest import skipIf
 
 root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 test_dir = os.path.dirname(os.path.abspath(__file__))
 fixtures_path = os.path.join(test_dir, 'fixtures')
+session = GitHubSession()
+
+temp_repo_dir = tempfile.mkdtemp()
 
 
 def load_fixture(filename):
@@ -46,7 +52,8 @@ _images = {}
 
 
 def requires_image(image):
-    """Decorator for checking docker image existance.
+    """Decorator for checking docker image existence.
+
     Image existence is cached on first check.
     """
     if image not in _images:
@@ -59,10 +66,21 @@ clone_path = os.path.join(test_dir, 'test_clone')
 cant_write_to_test = not(os.access(test_dir, os.W_OK))
 
 
-def setup_repo():
+@patch('lintreview.git.checkout')
+@patch('lintreview.git.fetch')
+def setup_repo(mock_fetch, mock_checkout):
+    """Set up a repo, avoiding fetch and checkout."""
+    git_dir = os.path.join(temp_repo_dir, 'test_clone')
+    if not os.path.exists(git_dir):
+        git.clone_or_update(
+            {},
+            'git://github.com/markstory/lint-review.git',
+            git_dir,
+            'master')
+
     git.clone_or_update(
         {},
-        'git://github.com/markstory/lint-review.git',
+        git_dir,
         clone_path,
         'master')
 

--- a/tests/fixers/test_commit_strategy.py
+++ b/tests/fixers/test_commit_strategy.py
@@ -1,127 +1,131 @@
 from __future__ import absolute_import
+from unittest import TestCase
 from lintreview.fixers.commit_strategy import CommitStrategy
 from lintreview.fixers.error import WorkflowError
 from mock import patch, Mock, sentinel
-from nose.tools import assert_in, assert_raises, with_setup, eq_
 from ..test_git import setup_repo, teardown_repo, clone_path
 
 
-def test_init_key_requirements():
-    keys = ('repo_path', 'author_email', 'author_name',
-            'pull_request')
-    values = ('some/path', 'lintbot', 'bot@example.com',
-              'pull#1')
-    for key in keys:
-        context = dict(zip(keys, values))
-        del context[key]
-        with assert_raises(KeyError):
-            CommitStrategy(context)
+class TestCommitStrategy(TestCase):
 
+    def setUp(self):
+        setup_repo()
 
-@with_setup(setup_repo, teardown_repo)
-@patch('lintreview.git.commit')
-@patch('lintreview.git.push')
-@patch('lintreview.git.apply_cached')
-def test_execute__push_error(mock_apply, mock_push, mock_commit):
-    mock_push.side_effect = IOError(
-            '! [remote rejected] stylefixes -> add_date_to_obs (permission denied)'
-            '\nerror: failed to push some refs to')
-    mock_pull = Mock(
-        head_branch='patch-1',
-        from_private_fork=False,
-        maintainer_can_modify=True)
-    context = {
-        'repo_path': clone_path,
-        'author_name': 'lintbot',
-        'author_email': 'lint@example.com',
-        'pull_request': mock_pull
-    }
-    strategy = CommitStrategy(context)
+    def tearDown(self):
+        teardown_repo()
 
-    diff = Mock()
-    diff.as_diff.return_value = sentinel.diff
-    with assert_raises(WorkflowError):
-        strategy.execute([diff])
+    def test_init_key_requirements(self):
+        keys = ('repo_path', 'author_email', 'author_name',
+                'pull_request')
+        values = ('some/path', 'lintbot', 'bot@example.com',
+                  'pull#1')
+        for key in keys:
+            context = dict(zip(keys, values))
+            del context[key]
+            self.assertRaises(KeyError,
+                              CommitStrategy,
+                              context)
 
+    @patch('lintreview.git.commit')
+    @patch('lintreview.git.push')
+    @patch('lintreview.git.apply_cached')
+    def test_execute__push_error(self, mock_apply, mock_push, mock_commit):
+        mock_push.side_effect = IOError(
+            '! [remote rejected] stylefixes -> add_date_to_obs '
+            '(permission denied)\nerror: failed to push some refs to')
+        mock_pull = Mock(
+            head_branch='patch-1',
+            from_private_fork=False,
+            maintainer_can_modify=True)
+        context = {
+            'repo_path': clone_path,
+            'author_name': 'lintbot',
+            'author_email': 'lint@example.com',
+            'pull_request': mock_pull
+        }
+        strategy = CommitStrategy(context)
 
-@with_setup(setup_repo, teardown_repo)
-@patch('lintreview.git.commit')
-@patch('lintreview.git.push')
-@patch('lintreview.git.apply_cached')
-def test_execute__git_flow(mock_apply, mock_push, mock_commit):
-    mock_pull = Mock(
-        head_branch='patch-1',
-        from_private_fork=False,
-        maintainer_can_modify=True)
-    context = {
-        'repo_path': clone_path,
-        'author_name': 'lintbot',
-        'author_email': 'lint@example.com',
-        'pull_request': mock_pull
-    }
-    strategy = CommitStrategy(context)
+        diff = Mock()
+        diff.as_diff.return_value = sentinel.diff
+        self.assertRaises(WorkflowError,
+                          strategy.execute,
+                          [diff])
 
-    diff = Mock()
-    diff.as_diff.return_value = sentinel.diff
-    out = strategy.execute([diff])
-    eq_(None, out)
+    @patch('lintreview.git.commit')
+    @patch('lintreview.git.push')
+    @patch('lintreview.git.apply_cached')
+    def test_execute__git_flow(self, mock_apply, mock_push, mock_commit):
+        mock_pull = Mock(
+            head_branch='patch-1',
+            from_private_fork=False,
+            maintainer_can_modify=True)
+        context = {
+            'repo_path': clone_path,
+            'author_name': 'lintbot',
+            'author_email': 'lint@example.com',
+            'pull_request': mock_pull
+        }
+        strategy = CommitStrategy(context)
 
-    mock_commit.assert_called_with(
-        clone_path,
-        'lintbot <lint@example.com>',
-        'Fixing style errors.')
-    mock_push.assert_called_with(
-        clone_path,
-        'origin',
-        'stylefixes:patch-1')
-    mock_apply.assert_called_with(
-        clone_path,
-        sentinel.diff)
+        diff = Mock()
+        diff.as_diff.return_value = sentinel.diff
+        out = strategy.execute([diff])
+        self.assertIsNone(out)
 
+        mock_commit.assert_called_with(
+            clone_path,
+            'lintbot <lint@example.com>',
+            'Fixing style errors.')
+        mock_push.assert_called_with(
+            clone_path,
+            'origin',
+            'stylefixes:patch-1')
+        mock_apply.assert_called_with(
+            clone_path,
+            sentinel.diff)
 
-@patch('lintreview.git.commit')
-def test_execute__no_maintainer_modify(mock_commit):
-    mock_pull = Mock(
-        head_branch='patch-1',
-        maintainer_can_modify=False,
-        from_private_fork=False)
-    context = {
-        'repo_path': clone_path,
-        'author_name': 'lintbot',
-        'author_email': 'lint@example.com',
-        'pull_request': mock_pull
-    }
-    strategy = CommitStrategy(context)
+    @patch('lintreview.git.commit')
+    def test_execute__no_maintainer_modify(self, mock_commit):
+        mock_pull = Mock(
+            head_branch='patch-1',
+            maintainer_can_modify=False,
+            from_private_fork=False)
+        context = {
+            'repo_path': clone_path,
+            'author_name': 'lintbot',
+            'author_email': 'lint@example.com',
+            'pull_request': mock_pull
+        }
+        strategy = CommitStrategy(context)
 
-    diff = Mock()
-    diff.as_diff.return_value = sentinel.diff
-    with assert_raises(WorkflowError) as err:
-        strategy.execute([diff])
+        diff = Mock()
+        diff.as_diff.return_value = sentinel.diff
+        with self.assertRaises(WorkflowError) as err:
+            strategy.execute([diff])
 
-    assert_in('Cannot apply automatic fixing', str(err.exception))
-    assert_in('modified by maintainers', str(err.exception))
-    eq_(0, mock_commit.call_count)
+        self.assertIn('Cannot apply automatic fixing', str(err.exception))
+        self.assertIn('modified by maintainers', str(err.exception))
+        self.assertEqual(0, mock_commit.call_count)
 
+    @patch('lintreview.git.commit')
+    def test_execute__private_fork(self, mock_commit):
+        mock_pull = Mock(
+            head_branch='patch-1',
+            maintainer_can_modify=True,
+            from_private_fork=True)
+        context = {
+            'repo_path': clone_path,
+            'author_name': 'lintbot',
+            'author_email': 'lint@example.com',
+            'pull_request': mock_pull
+        }
+        strategy = CommitStrategy(context)
 
-@patch('lintreview.git.commit')
-def test_execute__private_fork(mock_commit):
-    mock_pull = Mock(
-        head_branch='patch-1',
-        maintainer_can_modify=True,
-        from_private_fork=True)
-    context = {
-        'repo_path': clone_path,
-        'author_name': 'lintbot',
-        'author_email': 'lint@example.com',
-        'pull_request': mock_pull
-    }
-    strategy = CommitStrategy(context)
+        diff = Mock()
+        diff.as_diff.return_value = sentinel.diff
+        with self.assertRaises(WorkflowError) as err:
+            strategy.execute([diff])
 
-    diff = Mock()
-    diff.as_diff.return_value = sentinel.diff
-    with assert_raises(WorkflowError) as err:
-        strategy.execute([diff])
-
-    assert_in('Cannot apply automatic fixing', str(err.exception))
-    assert_in('private fork', str(err.exception))
-    eq_(0, mock_commit.call_count)
+        self.assertIn('Cannot apply automatic fixing', str(err.exception))
+        self.assertIn('private fork', str(err.exception))
+        self.assertEqual(0, mock_commit.call_count)

--- a/tests/fixers/test_init.py
+++ b/tests/fixers/test_init.py
@@ -1,15 +1,10 @@
 from __future__ import absolute_import
+from unittest import TestCase
 import lintreview.fixers as fixers
 from lintreview.config import build_review_config
 from lintreview.diff import parse_diff, Diff
 from lintreview.tools.phpcs import Phpcs
 from mock import Mock, sentinel
-from nose.tools import (
-    assert_raises,
-    assert_in,
-    eq_,
-    with_setup
-)
 from .. import requires_image, load_fixture, fixtures_path, fixer_ini
 from ..test_git import setup_repo, teardown_repo, clone_path
 
@@ -20,153 +15,151 @@ app_config = {
 }
 
 
-def test_run_fixers():
-    # Test that fixers are executed if fixer is enabled
-    mock_tool = Mock()
-    mock_tool.has_fixer.return_value = True
-    files = ['diff/adjacent_original.txt']
+class TestInit(TestCase):
+    def setUp(self):
+        setup_repo()
 
-    out = fixers.run_fixers([mock_tool], fixtures_path, files)
-    eq_(1, mock_tool.execute_fixer.call_count)
-    eq_(0, len(out))
+    def tearDown(self):
+        teardown_repo()
 
+    def test_run_fixers(self):
+        # Test that fixers are executed if fixer is enabled
+        mock_tool = Mock()
+        mock_tool.has_fixer.return_value = True
+        files = ['diff/adjacent_original.txt']
 
-def test_run_fixers__no_fixer_mode():
-    # Test that fixers are skipped when has_fixer fails
-    # Test that fixers are executed if fixer is enabled
-    mock_tool = Mock()
-    mock_tool.has_fixer.return_value = False
-    files = ['diff/adjacent_original.txt']
+        out = fixers.run_fixers([mock_tool], fixtures_path, files)
+        self.assertEqual(1, mock_tool.execute_fixer.call_count)
+        self.assertEqual(0, len(out))
 
-    out = fixers.run_fixers([mock_tool], fixtures_path, files)
-    eq_(0, mock_tool.execute_fixer.call_count)
-    eq_(0, len(out))
+    def test_run_fixers__no_fixer_mode(self):
+        # Test that fixers are skipped when has_fixer fails
+        # Test that fixers are executed if fixer is enabled
+        mock_tool = Mock()
+        mock_tool.has_fixer.return_value = False
+        files = ['diff/adjacent_original.txt']
 
+        out = fixers.run_fixers([mock_tool], fixtures_path, files)
+        self.assertEqual(0, mock_tool.execute_fixer.call_count)
+        self.assertEqual(0, len(out))
 
-@requires_image('phpcs')
-@with_setup(setup_repo, teardown_repo)
-def test_run_fixers__integration():
-    # Test fixer integration with phpcs.
-    tail_path = 'tests/fixtures/phpcs/has_errors.php'
-    phpcs = Phpcs(Mock(), {'fixer': True}, clone_path)
+    @requires_image('phpcs')
+    def test_run_fixers__integration(self):
+        # Test fixer integration with phpcs.
+        tail_path = 'tests/fixtures/phpcs/has_errors.php'
+        phpcs = Phpcs(Mock(), {'fixer': True}, clone_path)
 
-    diff = fixers.run_fixers([phpcs], clone_path, [tail_path])
-    eq_(1, len(diff))
-    eq_(tail_path, diff[0].filename)
+        diff = fixers.run_fixers([phpcs], clone_path, [tail_path])
+        self.assertEqual(1, len(diff))
+        self.assertEqual(tail_path, diff[0].filename)
 
+    def test_find_intersecting_diffs(self):
+        original = load_fixture('diff/intersecting_hunks_original.txt')
+        updated = load_fixture('diff/intersecting_hunks_updated.txt')
+        original = parse_diff(original)
+        updated = parse_diff(updated)
+        result = fixers.find_intersecting_diffs(original, updated)
 
-def test_find_intersecting_diffs():
-    original = load_fixture('diff/intersecting_hunks_original.txt')
-    updated = load_fixture('diff/intersecting_hunks_updated.txt')
-    original = parse_diff(original)
-    updated = parse_diff(updated)
-    result = fixers.find_intersecting_diffs(original, updated)
+        self.assertEqual(1, len(result))
+        assert isinstance(result[0], Diff)
+        self.assertEqual('model.php', result[0].filename)
+        self.assertEqual('00000', result[0].commit)
 
-    eq_(1, len(result))
-    assert isinstance(result[0], Diff)
-    eq_('model.php', result[0].filename)
-    eq_('00000', result[0].commit)
+    def test_find_intersecting_diffs__no_intersect(self):
+        original = load_fixture('diff/intersecting_hunks_original.txt')
+        updated = load_fixture('diff/adjacent_original.txt')
+        original = parse_diff(original)
+        updated = parse_diff(updated)
+        result = fixers.find_intersecting_diffs(original, updated)
 
+        self.assertEqual(0, len(result))
 
-def test_find_intersecting_diffs__no_intersect():
-    original = load_fixture('diff/intersecting_hunks_original.txt')
-    updated = load_fixture('diff/adjacent_original.txt')
-    original = parse_diff(original)
-    updated = parse_diff(updated)
-    result = fixers.find_intersecting_diffs(original, updated)
+    def test_find_intersecting_diffs__list(self):
+        diff = load_fixture('diff/intersecting_hunks_original.txt')
+        diffs = parse_diff(diff)
 
-    eq_(0, len(result))
+        result = fixers.find_intersecting_diffs(diffs, [])
+        self.assertEqual(0, len(result))
 
+        result = fixers.find_intersecting_diffs([], diff)
+        self.assertEqual(0, len(result))
 
-def test_find_intersecting_diffs__list():
-    diff = load_fixture('diff/intersecting_hunks_original.txt')
-    diffs = parse_diff(diff)
+    def test_apply_fixer_diff__missing_strategy_key(self):
+        original = Mock()
+        changed = Mock()
+        context = {}
 
-    result = fixers.find_intersecting_diffs(diffs, [])
-    eq_(0, len(result))
+        with self.assertRaises(fixers.ConfigurationError) as err:
+            fixers.apply_fixer_diff(original, changed, context)
+        self.assertIn('Missing', str(err.exception))
 
-    result = fixers.find_intersecting_diffs([], diff)
-    eq_(0, len(result))
+    def test_apply_fixer_diff__invalid_strategy(self):
+        original = Mock()
+        changed = Mock()
+        context = {'strategy': 'bad stategy'}
+        with self.assertRaises(fixers.ConfigurationError) as err:
+            fixers.apply_fixer_diff(original, changed, context)
+        self.assertIn('Unknown', str(err.exception))
 
+    def test_apply_fixer_diff__missing_strategy_context(self):
+        original = Mock()
+        changed = Mock()
+        context = {'strategy': 'commit'}
+        with self.assertRaises(fixers.ConfigurationError) as err:
+            fixers.apply_fixer_diff(original, changed, context)
+        self.assertIn('Could not create commit workflow', str(err.exception))
 
-def test_apply_fixer_diff__missing_strategy_key():
-    original = Mock()
-    changed = Mock()
-    context = {}
-    with assert_raises(fixers.ConfigurationError) as err:
-        fixers.apply_fixer_diff(original, changed, context)
-    assert_in('Missing', str(err.exception))
+    def test_apply_fixer_diff__calls_execute(self):
+        strategy_factory = Mock()
+        strategy = Mock()
+        strategy_factory.return_value = strategy
 
+        fixers.add_strategy('mock', strategy_factory)
 
-def test_apply_fixer_diff__invalid_strategy():
-    original = Mock()
-    changed = Mock()
-    context = {'strategy': 'bad stategy'}
-    with assert_raises(fixers.ConfigurationError) as err:
-        fixers.apply_fixer_diff(original, changed, context)
-    assert_in('Unknown', str(err.exception))
+        original = load_fixture('diff/intersecting_hunks_original.txt')
+        updated = load_fixture('diff/intersecting_hunks_updated.txt')
+        original = parse_diff(original)
+        updated = parse_diff(updated)
 
+        context = {'strategy': 'mock'}
+        fixers.apply_fixer_diff(original, updated, context)
+        self.assertEqual(1, strategy.execute.call_count)
 
-def test_apply_fixer_diff__missing_strategy_context():
-    original = Mock()
-    changed = Mock()
-    context = {'strategy': 'commit'}
-    with assert_raises(fixers.ConfigurationError) as err:
-        fixers.apply_fixer_diff(original, changed, context)
-    assert_in('Could not create commit workflow', str(err.exception))
+    def test_apply_fixer_diff__no_intersection(self):
+        strategy_factory = Mock()
+        strategy = Mock()
+        strategy_factory.return_value = strategy
 
+        fixers.add_strategy('mock', strategy_factory)
 
-def test_apply_fixer_diff__calls_execute():
-    strategy_factory = Mock()
-    strategy = Mock()
-    strategy_factory.return_value = strategy
+        original = load_fixture('diff/no_intersect_original.txt')
+        updated = load_fixture('diff/no_intersect_updated.txt')
+        original = parse_diff(original)
+        updated = parse_diff(updated)
 
-    fixers.add_strategy('mock', strategy_factory)
+        context = {'strategy': 'mock'}
+        fixers.apply_fixer_diff(original, updated, context)
+        self.assertEqual(0, strategy.execute.call_count)
 
-    original = load_fixture('diff/intersecting_hunks_original.txt')
-    updated = load_fixture('diff/intersecting_hunks_updated.txt')
-    original = parse_diff(original)
-    updated = parse_diff(updated)
-
-    context = {'strategy': 'mock'}
-    fixers.apply_fixer_diff(original, updated, context)
-    eq_(1, strategy.execute.call_count)
-
-
-def test_apply_fixer_diff__no_intersection():
-    strategy_factory = Mock()
-    strategy = Mock()
-    strategy_factory.return_value = strategy
-
-    fixers.add_strategy('mock', strategy_factory)
-
-    original = load_fixture('diff/no_intersect_original.txt')
-    updated = load_fixture('diff/no_intersect_updated.txt')
-    original = parse_diff(original)
-    updated = parse_diff(updated)
-
-    context = {'strategy': 'mock'}
-    fixers.apply_fixer_diff(original, updated, context)
-    eq_(0, strategy.execute.call_count)
-
-
-def test_create_context():
-    config = build_review_config(fixer_ini, app_config)
-    context = fixers.create_context(
-        config, clone_path,
-        sentinel.repo, sentinel.pull_request)
-
-    eq_('commit', context['strategy'])
-    eq_(config['GITHUB_AUTHOR_EMAIL'], context['author_email'])
-    eq_(config['GITHUB_AUTHOR_NAME'], context['author_name'])
-    eq_(clone_path, context['repo_path'])
-    eq_(sentinel.repo, context['repository'])
-    eq_(sentinel.pull_request, context['pull_request'])
-
-
-def test_create_context__missing_key_raises():
-    config = build_review_config(fixer_ini)
-    with assert_raises(KeyError):
-        fixers.create_context(
+    def test_create_context(self):
+        config = build_review_config(fixer_ini, app_config)
+        context = fixers.create_context(
             config, clone_path,
             sentinel.repo, sentinel.pull_request)
+
+        self.assertEqual('commit', context['strategy'])
+        self.assertEqual(config['GITHUB_AUTHOR_EMAIL'],
+                         context['author_email'])
+        self.assertEqual(config['GITHUB_AUTHOR_NAME'], context['author_name'])
+        self.assertEqual(clone_path, context['repo_path'])
+        self.assertEqual(sentinel.repo, context['repository'])
+        self.assertEqual(sentinel.pull_request, context['pull_request'])
+
+    def test_create_context__missing_key_raises(self):
+        config = build_review_config(fixer_ini)
+        self.assertRaises(KeyError,
+                          fixers.create_context,
+                          config,
+                          clone_path,
+                          sentinel.repo,
+                          sentinel.pull_request)

--- a/tests/fixtures/black/has_errors.py
+++ b/tests/fixtures/black/has_errors.py
@@ -10,3 +10,4 @@ def thing_two(arg1, arg2):
     result=arg1*arg2
     if result != arg1:
         print('derp')
+

--- a/tests/fixtures/flake8/has_errors.py
+++ b/tests/fixtures/flake8/has_errors.py
@@ -1,0 +1,19 @@
+"""
+Sample Python File with PEP8 Errors.
+
+Used for testing the pep8.Tool
+"""
+# Create unused imports
+import os, re
+
+def thing(self):
+    """Do a thing that has errors."""
+    thing_two('arg1',
+     'arg2')
+    print('derp')
+
+def thing_two(arg1, arg2):
+    """Do a second thing that also has errors."""
+    result=arg1*arg2
+    if result <> arg1:
+        print('derp')

--- a/tests/fixtures/flake8/no_errors.py
+++ b/tests/fixtures/flake8/no_errors.py
@@ -1,0 +1,10 @@
+"""
+Sample Python File with No PEP8 Errors.
+
+Used for testing the pep8.Tool
+"""
+
+
+def does_something(thing):
+    """Do a thing and then return."""
+    return thing.buzz()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
 
-from nose.tools import eq_, raises
-
 from lintreview.config import build_review_config, get_lintrc_defaults
 from lintreview.config import load_config, ReviewConfig
 
@@ -30,15 +28,6 @@ config = /etc/jshint.json
 simple_ini = """
 [tools]
 linters = jshint
-"""
-
-fixer_ini = """
-[tools]
-linters = phps
-
-[fixers]
-enable = True
-workflow = pull_request
 """
 
 review_ini = """
@@ -73,40 +62,39 @@ app_config = {
 }
 
 
-def test_load_config():
-    res = load_config()
-    assert res['GITHUB_URL'].endswith, 'Exists and is stringy'
-
-
-def test_get_lintrc_defaults():
-    config = load_config()
-    res = get_lintrc_defaults(config)
-    assert res is None
-
-
-def test_build_review_config():
-    config = build_review_config(sample_ini, {})
-    assert isinstance(config, ReviewConfig)
-    eq_(3, len(config.linters()))
-
-
 class ReviewConfigTest(TestCase):
+
+    @staticmethod
+    def test_load_config():
+        res = load_config()
+        assert res['GITHUB_URL'].endswith, 'Exists and is stringy'
+
+    @staticmethod
+    def test_get_lintrc_defaults():
+        config = load_config()
+        res = get_lintrc_defaults(config)
+        assert res is None
+
+    def test_build_review_config(self):
+        config = build_review_config(sample_ini, {})
+        assert isinstance(config, ReviewConfig)
+        self.assertEqual(3, len(config.linters()))
 
     def test_linter_listing_bad(self):
         config = build_review_config(bad_ini)
         res = config.linters()
-        eq_(res, [])
+        self.assertEqual(res, [])
 
     def test_linter_listing(self):
         config = build_review_config(sample_ini)
         res = config.linters()
         expected = ['phpcs', 'pep8', 'jshint']
-        eq_(sorted(res), sorted(expected))
+        self.assertEqual(sorted(res), sorted(expected))
 
     def test_linter_config_bad(self):
         config = build_review_config(bad_ini)
         res = config.linter_config('phpcs')
-        eq_(res, {})
+        self.assertEqual(res, {})
 
     def test_linter_config(self):
         config = build_review_config(sample_ini)
@@ -115,21 +103,21 @@ class ReviewConfigTest(TestCase):
             'standard': 'test/CodeStandards',
             'config': 'test/phpcs.xml'
         }
-        eq_(res, expected)
+        self.assertEqual(res, expected)
 
         res = config.linter_config('not there')
-        eq_(res, {})
+        self.assertEqual(res, {})
 
     def test_ignore_patterns(self):
         config = build_review_config(sample_ini)
         res = config.ignore_patterns()
         expected = ['test/CodeStandards/test/**', 'vendor/**']
-        eq_(res, expected)
+        self.assertEqual(res, expected)
 
     def test_ignore_patterns_missing(self):
         config = ReviewConfig()
         res = config.ignore_patterns()
-        eq_(res, [])
+        self.assertEqual(res, [])
 
     def test_load_ini__override(self):
         config = ReviewConfig()
@@ -139,7 +127,7 @@ class ReviewConfigTest(TestCase):
         expected = {
             'config': './jshint.json',
         }
-        eq_(res, expected)
+        self.assertEqual(res, expected)
 
     def test_load_ini__multiple_merges_settings(self):
         config = ReviewConfig()
@@ -149,76 +137,79 @@ class ReviewConfigTest(TestCase):
         expected = {
             'config': '/etc/jshint.json',
         }
-        eq_(res, expected)
+        self.assertEqual(res, expected)
 
     def test_fixers_enabled(self):
         config = build_review_config(sample_ini)
-        eq_(False, config.fixers_enabled())
+        self.assertEqual(False, config.fixers_enabled())
 
         config = build_review_config(fixer_ini)
-        eq_(True, config.fixers_enabled())
+        self.assertEqual(True, config.fixers_enabled())
 
     def test_fixer_workflow(self):
         config = build_review_config(sample_ini)
-        eq_('commit', config.fixer_workflow())
+        self.assertEqual('commit', config.fixer_workflow())
 
         config = build_review_config(fixer_ini)
-        eq_('pull_request', config.fixer_workflow())
+        self.assertEqual('pull_request', config.fixer_workflow())
 
     def test_getitem(self):
         config = build_review_config(simple_ini, app_config)
-        eq_(app_config['SUMMARY_THRESHOLD'], config['SUMMARY_THRESHOLD'])
+        self.assertEqual(app_config['SUMMARY_THRESHOLD'],
+                         config['SUMMARY_THRESHOLD'])
 
-    @raises(KeyError)
     def test_getitem__error(self):
         config = build_review_config(simple_ini, app_config)
-        config['UNKNOWN']
+        with self.assertRaises(KeyError):
+            config['UNKNOWN']
 
     def test_get(self):
         config = build_review_config(simple_ini, app_config)
-        eq_(app_config['SUMMARY_THRESHOLD'], config.get('SUMMARY_THRESHOLD'))
-        eq_(None, config.get('unknown'))
-        eq_('default', config.get('unknown', 'default'))
+        self.assertEqual(app_config['SUMMARY_THRESHOLD'],
+                         config.get('SUMMARY_THRESHOLD'))
+        self.assertEqual(None, config.get('unknown'))
+        self.assertEqual('default', config.get('unknown', 'default'))
 
     def test_summary_threshold__undefined(self):
         config = build_review_config(simple_ini)
-        eq_(None, config.summary_threshold())
+        self.assertEqual(None, config.summary_threshold())
 
     def test_summary_threshold__app_config(self):
         config = build_review_config(simple_ini, app_config)
-        eq_(app_config['SUMMARY_THRESHOLD'], config.summary_threshold())
+        self.assertEqual(app_config['SUMMARY_THRESHOLD'],
+                         config.summary_threshold())
 
     def test_summary_threshold__job_config(self):
         config = build_review_config(review_ini, app_config)
-        eq_(25, config.summary_threshold())
+        self.assertEqual(25, config.summary_threshold())
 
     def test_passed_review_label__undefined(self):
         config = build_review_config(simple_ini)
-        eq_(None, config.passed_review_label())
+        self.assertEqual(None, config.passed_review_label())
 
     def test_passed_review_label__app_config(self):
         config = build_review_config(simple_ini, app_config)
-        eq_('no lint', config.passed_review_label())
+        self.assertEqual('no lint', config.passed_review_label())
 
     def test_passed_review_label__job_config(self):
         config = build_review_config(review_ini, app_config)
-        eq_('lint ok', config.passed_review_label())
+        self.assertEqual('lint ok', config.passed_review_label())
 
     def test_failed_review_status__undefined(self):
         config = build_review_config(simple_ini)
-        eq_('failure', config.failed_review_status())
+        self.assertEqual('failure', config.failed_review_status())
 
     def test_failed_review_status__app_config(self):
         config = build_review_config(simple_ini, {'PULLREQUEST_STATUS': True})
-        eq_('failure', config.failed_review_status())
+        self.assertEqual('failure', config.failed_review_status())
 
         config = build_review_config(simple_ini, {'PULLREQUEST_STATUS': False})
-        eq_('success', config.failed_review_status())
+        self.assertEqual('success', config.failed_review_status())
 
     def test_failed_review_status__job_config(self):
         config = build_review_config(review_ini, app_config)
-        eq_('success', config.failed_review_status())
+        self.assertEqual('success', config.failed_review_status())
 
         ini = "[review]\nfail_on_comments = true"
         config = build_review_config(ini, app_config)
-        eq_('failure', config.failed_review_status())
+        self.assertEqual('failure', config.failed_review_status())

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,51 +1,52 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 import lintreview.docker as docker
-from nose.tools import eq_, assert_in
-from tests import requires_image, test_dir
+from tests import test_dir, requires_image
 
 
-def test_replace_basedir():
-    files = ['/tmp/things/some/thing.py', 'some/other.py']
-    out = docker.replace_basedir('/tmp/things', files)
-    expected = ['/src/some/thing.py', '/src/some/other.py']
-    eq_(expected, out)
+class TestDocker(TestCase):
 
+    def test_replace_basedir(self):
+        files = ['/tmp/things/some/thing.py', 'some/other.py']
+        out = docker.replace_basedir('/tmp/things', files)
+        expected = ['/src/some/thing.py', '/src/some/other.py']
+        self.assertEqual(expected, out)
 
-def test_strip_base():
-    eq_('some/thing.py', docker.strip_base('/src/some/thing.py'))
-    eq_('some/thing.py', docker.strip_base('some/thing.py'))
-    eq_('some/src/thing.py', docker.strip_base('some/src/thing.py'))
+    def test_strip_base(self):
+        self.assertEqual('some/thing.py',
+                         docker.strip_base('/src/some/thing.py'))
+        self.assertEqual('some/thing.py', docker.strip_base('some/thing.py'))
+        self.assertEqual('some/src/thing.py',
+                         docker.strip_base('some/src/thing.py'))
 
+    def test_apply_base(self):
+        self.assertEqual('/src', docker.apply_base(''))
+        self.assertEqual('/src', docker.apply_base('/'))
+        self.assertEqual('/src/thing.py', docker.apply_base('thing.py'))
+        self.assertEqual('/src/some/thing.py',
+                         docker.apply_base('some/thing.py'))
+        self.assertEqual('thing.py', docker.apply_base('/some/thing.py'))
+        self.assertEqual('thing.py', docker.apply_base('/some/../../thing.py'))
 
-def test_apply_base():
-    eq_('/src', docker.apply_base(''))
-    eq_('/src', docker.apply_base('/'))
-    eq_('/src/thing.py', docker.apply_base('thing.py'))
-    eq_('/src/some/thing.py', docker.apply_base('some/thing.py'))
-    eq_('thing.py', docker.apply_base('/some/thing.py'))
-    eq_('thing.py', docker.apply_base('/some/../../thing.py'))
+    @requires_image('python2')
+    def test_run__unicode(self):
+        cmd = ['echo', "\u2620"]
+        output = docker.run('python2', cmd, test_dir)
+        self.assertEqual(output, "\u2620\n")
 
+    @requires_image('python2')
+    def test_run__named_container(self):
+        cmd = ['echo', "things"]
+        docker.run('python2', cmd, test_dir, name='test_container')
+        containers = docker.containers(include_stopped=True)
+        self.assertIn('test_container', containers)
+        docker.rm_container('test_container')
 
-@requires_image('python2')
-def test_run__unicode():
-    cmd = ['echo', u"\u2620"]
-    output = docker.run('python2', cmd, test_dir)
-    eq_(output, u"\u2620\n")
+        containers = docker.containers(include_stopped=True)
+        assert 'test_conainer' not in containers
 
-
-@requires_image('python2')
-def test_run__named_container():
-    cmd = ['echo', "things"]
-    docker.run('python2', cmd, test_dir, name='test_container')
-    containers = docker.containers(include_stopped=True)
-    assert_in('test_container', containers)
-    docker.rm_container('test_container')
-
-    containers = docker.containers(include_stopped=True)
-    assert 'test_conainer' not in containers
-
-
-@requires_image('python2')
-def test_images():
-    result = docker.images()
-    assert_in('python2', result)
+    @requires_image('python2')
+    def test_images(self):
+        result = docker.images()
+        self.assertIn('python2', result)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
-import lintreview.git as git
 import os
+from unittest import TestCase
+from mock import patch
+
+import lintreview.git as git
 from .test_github import config
 from . import (
     setup_repo,
@@ -8,217 +11,203 @@ from . import (
     clone_path,
     cant_write_to_test
 )
-from nose.tools import eq_, raises, assert_in, with_setup
 from unittest import skipIf
 
 settings = {
-    'WORKSPACE': clone_path + '/tests'
+    'WORKSPACE': os.path.join(clone_path, '/tests')
 }
 
 
-def noop():
-    pass
+class TestGit(TestCase):
 
+    def setUp(self):
+        setup_repo()
 
-def test_get_repo_path():
-    user = 'markstory'
-    repo = 'asset_compress'
-    num = '4'
-    res = git.get_repo_path(user, repo, num, settings)
-    expected = os.sep.join(
-        (settings['WORKSPACE'], user, repo, num))
-    expected = os.path.realpath(expected)
-    eq_(res, expected)
+    def tearDown(self):
+        teardown_repo()
 
+    def test_get_repo_path(self):
+        user = 'markstory'
+        repo = 'asset_compress'
+        num = '4'
+        res = git.get_repo_path(user, repo, num, settings)
+        expected = os.sep.join(
+            (settings['WORKSPACE'], user, repo, num))
+        expected = os.path.realpath(expected)
+        self.assertEqual(res, expected)
 
-def test_get_repo_path__int():
-    user = 'markstory'
-    repo = 'asset_compress'
-    num = 4
-    res = git.get_repo_path(user, repo, num, settings)
-    expected = os.sep.join(
-        (settings['WORKSPACE'], user, repo, str(num)))
-    expected = os.path.realpath(expected)
-    eq_(res, expected)
+    def test_get_repo_path__int(self):
+        user = 'markstory'
+        repo = 'asset_compress'
+        num = 4
+        res = git.get_repo_path(user, repo, num, settings)
+        expected = os.sep.join(
+            (settings['WORKSPACE'], user, repo, str(num)))
+        expected = os.path.realpath(expected)
+        self.assertEqual(res, expected)
 
+    def test_get_repo_path__absoulte_dir(self):
+        user = 'markstory'
+        repo = 'asset_compress'
+        num = 4
+        settings['WORKSPACE'] = os.path.realpath(settings['WORKSPACE'])
+        res = git.get_repo_path(user, repo, num, settings)
+        expected = os.sep.join(
+            (settings['WORKSPACE'], user, repo, str(num)))
+        expected = os.path.realpath(expected)
+        self.assertEqual(res, expected)
 
-def test_get_repo_path__absoulte_dir():
-    user = 'markstory'
-    repo = 'asset_compress'
-    num = 4
-    settings['WORKSPACE'] = os.path.realpath(settings['WORKSPACE'])
-    res = git.get_repo_path(user, repo, num, settings)
-    expected = os.sep.join(
-        (settings['WORKSPACE'], user, repo, str(num)))
-    expected = os.path.realpath(expected)
-    eq_(res, expected)
+    def test_exists__no_path(self):
+        assert not git.exists(settings['WORKSPACE'] + '/herp/derp')
 
+    def test_exists__no_git(self):
+        assert not git.exists(settings['WORKSPACE'])
 
-def test_exists__no_path():
-    assert not git.exists(settings['WORKSPACE'] + '/herp/derp')
+    def test_repo_clone_no_repo(self):
+        self.assertRaises(IOError,
+                          git.clone,
+                          'git://github.com/markstory/it will never work.git',
+                          clone_path)
 
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_repo_operations(self):
+        teardown_repo()
+        res = git.clone(
+            'git://github.com/markstory/lint-review.git',
+            clone_path)
+        assert res, 'Cloned successfully.'
+        assert git.exists(clone_path), 'Cloned dir should be there.'
+        git.destroy(clone_path)
+        assert not(git.exists(clone_path)), 'Cloned dir should be gone.'
 
-def test_exists__no_git():
-    assert not git.exists(settings['WORKSPACE'])
-
-
-@raises(IOError)
-@with_setup(noop, teardown_repo)
-def test_repo_clone_no_repo():
-    git.clone(
-        'git://github.com/markstory/it will never work.git',
-        clone_path)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-def test_repo_operations():
-    res = git.clone(
-        'git://github.com/markstory/lint-review.git',
-        clone_path)
-    assert res, 'Cloned successfully.'
-    assert git.exists(clone_path), 'Cloned dir should be there.'
-    git.destroy(clone_path)
-    assert not(git.exists(clone_path)), 'Cloned dir should be gone.'
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(noop, teardown_repo)
-def test_clone_or_update():
-    git.clone_or_update(
-        config,
-        'git://github.com/markstory/lint-review.git',
-        clone_path,
-        'e4f880c77e6b2c81c81cad5d45dd4e1c39b919a0')
-    assert git.exists(clone_path)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_diff():
-    with open(clone_path + '/README.mdown', 'w') as f:
-        f.write('New readme')
-    result = git.diff(clone_path)
-
-    assert_in('a/README.mdown', result)
-    assert_in('b/README.mdown', result)
-    assert_in('+New readme', result)
-    assert_in('-# Lint Review', result)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_diff__files_list():
-    with open(clone_path + '/README.mdown', 'w') as f:
-        f.write('New readme')
-    result = git.diff(clone_path, ['LICENSE'])
-    eq_('', result)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@raises(IOError)
-def test_diff__non_git_path():
-    path = os.path.abspath(clone_path + '/../../../')
-    git.diff(path)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_apply_cached():
-    with open(clone_path + '/README.mdown', 'w') as f:
-        f.write('New readme')
-    # Get the initial diff.
-    diff = git.diff(clone_path)
-    git.apply_cached(clone_path, diff)
-
-    # Changes have been staged, diff result should be empty.
-    diff = git.diff(clone_path)
-    eq_(diff, '')
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_apply_cached__empty():
-    git.apply_cached(clone_path, '')
-
-    # No changes, no diff.
-    diff = git.diff(clone_path)
-    eq_(diff, '')
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@raises(IOError)
-@with_setup(setup_repo, teardown_repo)
-def test_apply_cached__bad_patch():
-    git.apply_cached(clone_path, 'not a diff')
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@raises(IOError)
-def test_apply_cached__non_git_path():
-    path = os.path.abspath(clone_path + '/../../')
-    git.apply_cached(path, 'not a patch')
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_commit_and_status():
-    with open(clone_path + '/README.mdown', 'w') as f:
-        f.write('New readme')
-    diff = git.diff(clone_path)
-
-    status = git.status(clone_path)
-    assert 'README.mdown' in status
-
-    git.apply_cached(clone_path, diff)
-    git.commit(clone_path, 'robot <bot@example.com>', 'Fixed readme')
-    status = git.status(clone_path)
-    eq_('', status, 'No changes unstaged, or uncommitted')
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_add_remote():
-    output = git.add_remote(
-        clone_path,
-        'testing',
-        'git://github.com/markstory/lint-review.git')
-    eq_('', output)
-
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_add_remote__duplicate():
-    try:
-        git.add_remote(
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    @patch('lintreview.git.checkout')
+    @patch('lintreview.git.fetch')
+    def test_clone_or_update(self, mock_fetch, mock_checkout):
+        teardown_repo()
+        git.clone_or_update(
+            config,
+            'git://github.com/markstory/lint-review.git',
             clone_path,
-            'origin',
+            'e4f880c77e6b2c81c81cad5d45dd4e1c39b919a0')
+        assert git.exists(clone_path)
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_diff(self):
+        with open(clone_path + '/README.mdown', 'w') as f:
+            f.write('New readme')
+        result = git.diff(clone_path)
+
+        self.assertIn('a/README.mdown', result)
+        self.assertIn('b/README.mdown', result)
+        self.assertIn('+New readme', result)
+        self.assertIn('-# Lint Review', result)
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_diff__files_list(self):
+        with open(clone_path + '/README.mdown', 'w') as f:
+            f.write('New readme')
+        result = git.diff(clone_path, ['LICENSE'])
+        self.assertEqual('', result)
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_diff__non_git_path(self):
+        path = os.path.abspath(clone_path + '/../../../')
+        self.assertRaises(
+            IOError,
+            git.diff,
+            path
+        )
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_apply_cached(self):
+        with open(clone_path + '/README.mdown', 'w') as f:
+            f.write('New readme')
+        # Get the initial diff.
+        diff = git.diff(clone_path)
+        git.apply_cached(clone_path, diff)
+
+        # Changes have been staged, diff result should be empty.
+        diff = git.diff(clone_path)
+        self.assertEqual(diff, '')
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_apply_cached__empty(self):
+        git.apply_cached(clone_path, '')
+
+        # No changes, no diff.
+        diff = git.diff(clone_path)
+        self.assertEqual(diff, '')
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_apply_cached__bad_patch(self):
+        self.assertRaises(
+            IOError,
+            git.apply_cached,
+            clone_path,
+            'not a diff'
+        )
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_apply_cached__non_git_path(self):
+        path = os.path.abspath(clone_path + '/../../')
+        self.assertRaises(
+            IOError,
+            git.apply_cached,
+            path,
+            'not a patch'
+        )
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_commit_and_status(self):
+        with open(clone_path + '/README.mdown', 'w') as f:
+            f.write('New readme')
+        diff = git.diff(clone_path)
+
+        status = git.status(clone_path)
+        assert 'README.mdown' in status
+
+        git.apply_cached(clone_path, diff)
+        git.commit(clone_path, 'robot <bot@example.com>', 'Fixed readme')
+        status = git.status(clone_path)
+        self.assertEqual('', status, 'No changes unstaged, or uncommitted')
+
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_add_remote(self):
+        output = git.add_remote(
+            clone_path,
+            'testing',
             'git://github.com/markstory/lint-review.git')
-    except IOError as e:
-        assert_in('Unable to add remote origin', str(e))
+        self.assertEqual('', output)
 
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_add_remote__duplicate(self):
+        try:
+            git.add_remote(
+                clone_path,
+                'origin',
+                'git://github.com/markstory/lint-review.git')
+        except IOError as e:
+            self.assertIn('Unable to add remote origin', str(e))
 
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_push__fails():
-    try:
-        git.push(clone_path, 'origin', 'master')
-    except IOError as e:
-        assert_in('origin:master', str(e))
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_push__fails(self):
+        try:
+            git.push(clone_path, 'origin', 'master')
+        except IOError as e:
+            self.assertIn('origin:master', str(e))
 
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_create_branch(self):
+        git.create_branch(clone_path, 'testing')
+        self.assertEqual(True, git.branch_exists(clone_path, 'master'))
+        self.assertEqual(True, git.branch_exists(clone_path, 'testing'))
+        self.assertEqual(False, git.branch_exists(clone_path, 'nope'))
 
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, teardown_repo)
-def test_create_branch():
-    git.create_branch(clone_path, 'testing')
-    eq_(True, git.branch_exists(clone_path, 'master'))
-    eq_(True, git.branch_exists(clone_path, 'testing'))
-    eq_(False, git.branch_exists(clone_path, 'nope'))
+    @skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
+    def test_destroy_unicode_paths(self):
+        full_clone_path = os.path.join(clone_path, "\u2620.txt")
+        with open(full_clone_path, 'w') as f:
+            f.write('skull and crossbones')
 
-
-@skipIf(cant_write_to_test, 'Cannot write to ./tests skipping')
-@with_setup(setup_repo, noop)
-def test_destory_unicode_paths():
-    with open(clone_path + u"/\u2620.txt", 'w') as f:
-        f.write('skull and crossbones')
-
-    git.destroy(clone_path)
+        git.destroy(clone_path)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,101 +1,101 @@
 from __future__ import absolute_import
+import json
+from mock import call, Mock
+from unittest import TestCase
+
 import lintreview.github as github
 
 from . import load_fixture
-from mock import call, Mock
-from nose.tools import eq_
 import github3
 from github3 import GitHub
-import json
+from github3.session import GitHubSession
+from github3.repos import Repository
+from github3.repos.hook import Hook
 
 
 config = {
     'GITHUB_URL': 'https://api.github.com/',
 }
+session = GitHubSession()
 
 
-def test_get_client():
-    conf = config.copy()
-    conf['GITHUB_OAUTH_TOKEN'] = 'an-oauth-token'
-    gh = github.get_client(conf)
-    assert isinstance(gh, GitHub)
+class TestGithub(TestCase):
 
+    def test_get_client(self):
+        conf = config.copy()
+        conf['GITHUB_OAUTH_TOKEN'] = 'an-oauth-token'
+        gh = github.get_client(conf)
+        assert isinstance(gh, GitHub)
 
-def test_get_client__retry_opts():
-    conf = config.copy()
-    conf['GITHUB_OAUTH_TOKEN'] = 'an-oauth-token'
-    conf['GITHUB_CLIENT_RETRY_OPTIONS'] = {'backoff_factor': 42}
-    gh = github.get_client(conf)
+    def test_get_client__retry_opts(self):
+        conf = config.copy()
+        conf['GITHUB_OAUTH_TOKEN'] = 'an-oauth-token'
+        conf['GITHUB_CLIENT_RETRY_OPTIONS'] = {'backoff_factor': 42}
+        gh = github.get_client(conf)
 
-    for proto in ('https://', 'http://'):
-        eq_(gh.session.get_adapter(proto).max_retries.backoff_factor, 42)
+        for proto in ('https://', 'http://'):
+            actual = gh.session.get_adapter(proto).max_retries.backoff_factor
+            self.assertEqual(actual, 42)
 
+    def test_get_lintrc(self):
+        repo = Mock(spec=Repository)
+        github.get_lintrc(repo, 'HEAD')
+        repo.file_contents.assert_called_with('.lintrc', 'HEAD')
 
-def test_get_lintrc():
-    repo = Mock(spec=github3.repos.repo.Repository)
-    github.get_lintrc(repo, 'HEAD')
-    repo.file_contents.assert_called_with('.lintrc', 'HEAD')
+    def test_register_hook(self):
+        repo = Mock(spec=Repository,
+                    full_name='mark/lint-review')
+        repo.hooks.return_value = []
 
+        url = 'http://example.com/review/start'
+        github.register_hook(repo, url)
 
-def test_register_hook():
-    repo = Mock(spec=github3.repos.repo.Repository,
-                full_name='mark/lint-review')
-    repo.hooks.return_value = []
+        assert repo.create_hook.called, 'Create not called'
+        calls = repo.create_hook.call_args_list
+        expected = call(
+            name='web',
+            active=True,
+            config={
+                'content_type': 'json',
+                'url': url,
+            },
+            events=['pull_request']
+        )
+        self.assertEqual(calls[0], expected)
 
-    url = 'http://example.com/review/start'
-    github.register_hook(repo, url)
+    def test_register_hook__already_exists(self):
+        repo = Mock(spec=Repository,
+                    full_name='mark/lint-review')
+        repo.hooks.return_value = [
+            Hook(f, session)
+            for f in json.loads(load_fixture('webhook_list.json'))
+        ]
+        url = 'http://example.com/review/start'
 
-    assert repo.create_hook.called, 'Create not called'
-    calls = repo.create_hook.call_args_list
-    expected = call(
-        name='web',
-        active=True,
-        config={
-            'content_type': 'json',
-            'url': url,
-        },
-        events=['pull_request']
-    )
-    eq_(calls[0], expected)
+        github.register_hook(repo, url)
+        assert repo.create_hook.called is False, 'Create called'
 
-
-def test_register_hook__already_exists():
-    repo = Mock(spec=github3.repos.repo.Repository,
-                full_name='mark/lint-review')
-    session = github.get_session()
-    repo.hooks.return_value = [
+    def test_unregister_hook__success(self):
+        repo = Mock(spec=Repository,
+                    full_name='mark/lint-review')
+        hooks = [
             github3.repos.hook.Hook(f, session)
             for f in json.loads(load_fixture('webhook_list.json'))
         ]
-    url = 'http://example.com/review/start'
-
-    github.register_hook(repo, url)
-    assert repo.create_hook.called is False, 'Create called'
-
-
-def test_unregister_hook__success():
-    repo = Mock(spec=github3.repos.repo.Repository,
-                full_name='mark/lint-review')
-    session = github3.session.GitHubSession()
-    hooks = [
-        github3.repos.hook.Hook(f, session)
-        for f in json.loads(load_fixture('webhook_list.json'))
-        ]
-    repo.hooks.return_value = hooks
-    url = 'http://example.com/review/start'
-    github.unregister_hook(repo, url)
-    assert repo.hook().delete.called, 'Delete not called'
-
-
-def test_unregister_hook__not_there():
-    repo = Mock(spec=github3.repos.repo.Repository,
-                full_name='mark/lint-review')
-    repo.hooks.return_value = []
-    url = 'http://example.com/review/start'
-
-    try:
+        repo.hooks.return_value = hooks
+        url = 'http://example.com/review/start'
         github.unregister_hook(repo, url)
-        assert False, 'No exception'
-    except:
-        assert True, 'Exception raised'
-    assert repo.hook().delete.called is False, 'Delete called'
+        assert repo.hook().delete.called, 'Delete not called'
+
+    def test_unregister_hook__not_there(self):
+        repo = Mock(spec=Repository,
+                    full_name='mark/lint-review')
+        repo.hooks.return_value = []
+        url = 'http://example.com/review/start'
+
+        self.assertRaises(Exception,
+                          github.unregister_hook,
+                          repo,
+                          url)
+
+        repo.hook().delete.asert_called()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -10,7 +10,6 @@ from lintreview.config import load_config
 from lintreview.repo import GithubRepository
 from lintreview.repo import GithubPullRequest
 from mock import Mock, patch, sentinel
-from nose.tools import eq_, ok_
 from unittest import TestCase
 
 config = load_config()
@@ -27,7 +26,7 @@ class TestGithubRepository(TestCase):
         github_mock.get_repository.return_value = self.repo_model
         repo = GithubRepository(config, 'markstory', 'lint-test')
 
-        eq_(self.repo_model, repo.repository())
+        self.assertEqual(self.repo_model, repo.repository())
         github_mock.get_repository.assert_called_with(
             config,
             'markstory',
@@ -39,8 +38,8 @@ class TestGithubRepository(TestCase):
         repo = GithubRepository(config, 'markstory', 'lint-test')
         repo.repository = lambda: self.repo_model
         pull = repo.pull_request(1)
-        ok_(isinstance(pull, GithubPullRequest),
-            'Should be wrapped object')
+        self.assertIsInstance(pull, GithubPullRequest,
+                              'Should be wrapped object')
 
     def test_ensure_label__missing(self):
         model = self.repo_model
@@ -62,7 +61,7 @@ class TestGithubRepository(TestCase):
         repo = GithubRepository(config, 'markstory', 'lint-test')
         repo.repository = lambda: self.repo_model
         repo.ensure_label('A label')
-        eq_(False, model.create_label.called)
+        self.assertEqual(False, model.create_label.called)
 
     def test_create_status(self):
         model = self.repo_model
@@ -80,8 +79,10 @@ class TestGithubRepository(TestCase):
 
     def test_create_checkrun(self):
         model = self.repo_model
-        model._post = Mock()
-        model._json = Mock()
+        post_mock = Mock()
+        json_mock = Mock()
+        model._post = post_mock
+        model._json = json_mock
 
         repo = GithubRepository(config, 'markstory', 'lint-test')
         repo.repository = lambda: model
@@ -95,11 +96,11 @@ class TestGithubRepository(TestCase):
             }
         }
         repo.create_checkrun(review)
-        model._post.assert_called_with(
+        post_mock.assert_called_with(
             'https://api.github.com/repos/markstory/lint-test/check-runs',
             data=review,
             headers={'Accept': 'application/vnd.github.antiope-preview+json'})
-        assert model._json.called
+        json_mock.assert_called()
 
     def test_update_checkrun(self):
         model = self.repo_model
@@ -220,7 +221,7 @@ class TestGithubPullRequest(TestCase):
 
     def test_maintainer_can_modify__same_repo(self):
         pull = GithubPullRequest(self.model)
-        eq_(True, pull.maintainer_can_modify)
+        self.assertEqual(True, pull.maintainer_can_modify)
 
         fixture = load_fixture('pull_request.json')
         data = json.loads(fixture)
@@ -228,7 +229,7 @@ class TestGithubPullRequest(TestCase):
 
         model = PullRequest(data, self.session)
         pull = GithubPullRequest(model)
-        eq_(True, pull.maintainer_can_modify)
+        self.assertEqual(True, pull.maintainer_can_modify)
 
     def test_maintainer_can_modify__forked_repo(self):
         fixture = load_fixture('pull_request.json')
@@ -237,25 +238,25 @@ class TestGithubPullRequest(TestCase):
         # Make repo different
         data['head']['repo']['full_name'] = 'contributor/lint-test'
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(True, pull.maintainer_can_modify, 'reflects flag')
+        self.assertEqual(True, pull.maintainer_can_modify, 'reflects flag')
 
         # Different repo reflects flag data
         data['maintainer_can_modify'] = False
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(False, pull.maintainer_can_modify)
+        self.assertEqual(False, pull.maintainer_can_modify)
 
         data['maintainer_can_modify'] = True
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(True, pull.maintainer_can_modify)
+        self.assertEqual(True, pull.maintainer_can_modify)
 
     def test_clone_url__private_fork__not_a_fork(self):
         fixture = load_fixture('pull_request.json')
         data = json.loads(fixture)
 
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(False, pull.from_private_fork)
-        eq_(data['head']['repo']['clone_url'], pull.clone_url)
-        eq_('test', pull.head_branch)
+        self.assertEqual(False, pull.from_private_fork)
+        self.assertEqual(data['head']['repo']['clone_url'], pull.clone_url)
+        self.assertEqual('test', pull.head_branch)
 
     def test_clone_url__private_fork__forked(self):
         fixture = load_fixture('pull_request.json')
@@ -265,7 +266,7 @@ class TestGithubPullRequest(TestCase):
         data['head']['repo']['fork'] = True
 
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(False, pull.from_private_fork)
+        self.assertEqual(False, pull.from_private_fork)
 
     def test_clone_url__private_fork(self):
         fixture = load_fixture('pull_request.json')
@@ -276,9 +277,9 @@ class TestGithubPullRequest(TestCase):
         data['head']['repo']['fork'] = True
         data['head']['repo']['private'] = True
         pull = GithubPullRequest(PullRequest(data, self.session))
-        eq_(True, pull.from_private_fork)
-        eq_(data['base']['repo']['clone_url'], pull.clone_url)
-        eq_('refs/pull/1/head', pull.head_branch)
+        self.assertEqual(True, pull.from_private_fork)
+        self.assertEqual(data['base']['repo']['clone_url'], pull.clone_url)
+        self.assertEqual('refs/pull/1/head', pull.head_branch)
 
 
 @contextmanager

--- a/tests/tools/test_ansible.py
+++ b/tests/tools/test_ansible.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Problems, Comment
 from lintreview.tools.ansible import Ansible
-from unittest import TestCase
-from nose.tools import eq_
 from tests import requires_image, root_dir
 
 
@@ -28,46 +28,46 @@ class TestAnsible(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(11, len(problems))
+        self.assertEqual(11, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
             fname, 12, 12,
             '[EANSIBLE0012] Commands should not change things if nothing needs doing'  # noqa
         )
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             fname, 18, 18,
             '[EANSIBLE0004] Git checkouts must contain explicit version'  # noqa
         )
-        eq_(expected, problems[3])
+        self.assertEqual(expected, problems[3])
 
     @requires_image('python2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(11, len(problems))
+        self.assertEqual(11, len(problems))
         expected = Comment(
             self.fixtures[1], 12, 12,
             '[EANSIBLE0012] Commands should not change things if nothing needs doing'  # noqa
         )
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             self.fixtures[1], 27, 27,
             '[EANSIBLE0006] git used in place of git module'
         )
-        eq_(expected, problems[5])
+        self.assertEqual(expected, problems[5])
 
     @requires_image('python2')
     def test_config_options_and_process_file(self):
@@ -77,7 +77,7 @@ class TestAnsible(TestCase):
         self.tool = Ansible(self.problems, options, root_dir)
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(7, len(problems))
+        self.assertEqual(7, len(problems))
         for p in problems:
             self.assertFalse('ANSIBLE0012' in p.body)
             self.assertFalse('ANSIBLE0006' in p.body)

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems
 from lintreview.tools.black import Black
 from unittest import TestCase
-from nose.tools import eq_, assert_in, assert_not_in
 from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
@@ -27,33 +26,33 @@ class TestBlack(TestCase):
     @requires_image('python3')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python3')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all()
 
-        eq_(1, len(problems))
-        assert_in('* ' + self.fixtures[1], problems[0].body)
+        self.assertEqual(1, len(problems))
+        self.assertIn('* ' + self.fixtures[1], problems[0].body)
 
     @requires_image('python3')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
         problems = self.problems.all()
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
-        assert_in('do not match the `black` styleguide', problems[0].body)
-        assert_in('* ' + self.fixtures[1], problems[0].body)
-        assert_not_in(self.fixtures[0], problems[0].body)
+        self.assertIn('do not match the `black` styleguide', problems[0].body)
+        self.assertIn('* ' + self.fixtures[1], problems[0].body)
+        self.assertNotIn(self.fixtures[0], problems[0].body)
 
     @requires_image('python3')
     def test_process_absolute_container_path(self):
         fixtures = ['/src/' + path for path in self.fixtures]
         self.tool.process_files(fixtures)
 
-        eq_(1, len(self.problems.all()))
+        self.assertEqual(1, len(self.problems.all()))
 
     @requires_image('python3')
     def test_process_files__config(self):
@@ -64,16 +63,16 @@ class TestBlack(TestCase):
         self.tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all()
-        eq_(1, len(problems))
-        assert_in(self.fixtures[1], problems[0].body)
+        self.assertEqual(1, len(problems))
+        self.assertIn(self.fixtures[1], problems[0].body)
 
     def test_has_fixer__not_enabled(self):
         tool = Black(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Black(self.problems, {'fixer': True})
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('python3')
     def test_execute_fixer(self):
@@ -85,4 +84,5 @@ class TestBlack(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')

--- a/tests/tools/test_checkstyle.py
+++ b/tests/tools/test_checkstyle.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.checkstyle import Checkstyle
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -11,7 +10,7 @@ class TestCheckstyle(TestCase):
     fixtures = [
         'tests/fixtures/checkstyle/no_errors.java',
         'tests/fixtures/checkstyle/has_errors.java',
-        u'tests/fixtures/checkstyle/\u6c92\u6709\u932f\u8aa4.java',
+        'tests/fixtures/checkstyle/\u6c92\u6709\u932f\u8aa4.java',
     ]
 
     def setUp(self):
@@ -35,13 +34,13 @@ class TestCheckstyle(TestCase):
     @requires_image('checkstyle')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('checkstyle')
     def test_process_files__multiple_error(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(4, len(problems))
+        self.assertEqual(4, len(problems))
 
         fname = self.fixtures[1]
 
@@ -51,7 +50,7 @@ class TestCheckstyle(TestCase):
             1,
             "Missing a Javadoc comment.\n"
             "Utility classes should not have a public or default constructor.")
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             fname,
@@ -60,16 +59,16 @@ class TestCheckstyle(TestCase):
             "Missing a Javadoc comment.\n"
             "Parameter args should be final."
         )
-        eq_(expected, problems[2])
+        self.assertEqual(expected, problems[2])
 
     @requires_image('checkstyle')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(4, len(problems))
+        self.assertEqual(4, len(problems))
 
     @requires_image('checkstyle')
     def test_process_files__no_config_comment(self):
@@ -78,8 +77,8 @@ class TestCheckstyle(TestCase):
         tool.process_files(self.fixtures)
 
         problems = self.problems.all()
-        eq_(1, len(problems))
-        assert_in('could not run `checkstyle`', problems[0].body)
+        self.assertEqual(1, len(problems))
+        self.assertIn('could not run `checkstyle`', problems[0].body)
 
     @requires_image('checkstyle')
     def test_process_files__missing_config(self):
@@ -88,9 +87,9 @@ class TestCheckstyle(TestCase):
         tool.process_files(self.fixtures)
 
         problems = self.problems.all()
-        eq_(1, len(problems))
-        assert_in('Running `checkstyle` failed', problems[0].body)
-        assert_in('config file exists and is valid XML', problems[0].body)
+        self.assertEqual(1, len(problems))
+        self.assertIn('Running `checkstyle` failed', problems[0].body)
+        self.assertIn('config file exists and is valid XML', problems[0].body)
 
     def test_create_command__with_path_based_standard(self):
         config = {
@@ -106,4 +105,4 @@ class TestCheckstyle(TestCase):
             'some/file.js'
         ]
         assert 'checkstyle' in result[0], 'checkstyle is in command name'
-        eq_(result, expected)
+        self.assertEqual(result, expected)

--- a/tests/tools/test_commitcheck.py
+++ b/tests/tools/test_commitcheck.py
@@ -3,7 +3,6 @@ from tests import load_fixture, create_commits
 from lintreview.review import Problems
 from lintreview.review import IssueComment
 from lintreview.tools.commitcheck import Commitcheck
-from nose.tools import eq_
 from unittest import TestCase
 
 
@@ -19,45 +18,45 @@ class TestCommitCheck(TestCase):
     def test_execute_commits__no_pattern(self):
         self.tool.options['pattern'] = ''
         self.tool.execute_commits(self.fixture_data)
-        eq_(0, len(self.problems), 'Empty pattern does not find issues')
+        self.assertEqual(0, len(self.problems), 'Empty pattern does not find issues')
 
     def test_execute_commits__broken_regex(self):
         self.tool.options['pattern'] = '(.*'
         self.tool.execute_commits(self.fixture_data)
-        eq_(0, len(self.problems), 'Empty pattern does not find issues')
+        self.assertEqual(0, len(self.problems), 'Empty pattern does not find issues')
 
     def test_execute_commits__match(self):
         self.tool.options['pattern'] = '\w+'
         self.tool.execute_commits(self.fixture_data)
-        eq_(0, len(self.problems), 'Commits that do match are ok')
+        self.assertEqual(0, len(self.problems), 'Commits that do match are ok')
 
         self.tool.options['pattern'] = 'bugs?'
         self.tool.execute_commits(self.fixture_data)
-        eq_(0, len(self.problems), 'Commits that do match are ok')
+        self.assertEqual(0, len(self.problems), 'Commits that do match are ok')
 
     def test_execute_commits__no_match(self):
         self.tool.options['pattern'] = '\d+'
         self.tool.execute_commits(self.fixture_data)
-        eq_(1, len(self.problems), 'Commits that do not match cause errors')
+        self.assertEqual(1, len(self.problems), 'Commits that do not match cause errors')
         msg = (
             'The following commits had issues. '
             'The pattern \d+ was not found in:\n'
             '* 6dcb09b5b57875f334f61aebed695e2e4193db5e\n')
         expected = IssueComment(msg)
-        eq_(expected, self.problems.all()[0])
+        self.assertEqual(expected, self.problems.all()[0])
 
     def test_execute_commits__custom_message(self):
         self.tool.options['pattern'] = '\d+'
         self.tool.options['message'] = 'You are bad.'
         self.tool.execute_commits(self.fixture_data)
-        eq_(1, len(self.problems), 'Commits that do not match cause errors')
+        self.assertEqual(1, len(self.problems), 'Commits that do not match cause errors')
         msg = ('You are bad. The pattern \d+ was not found in:\n'
                '* 6dcb09b5b57875f334f61aebed695e2e4193db5e\n')
         expected = IssueComment(msg)
-        eq_(expected, self.problems.all()[0])
+        self.assertEqual(expected, self.problems.all()[0])
 
     def test_execute_commits__ignore_author_email(self):
         self.tool.author = 'support@github.com'
         self.tool.options['pattern'] = '\d+'
         self.tool.execute_commits(self.fixture_data)
-        eq_(0, len(self.problems))
+        self.assertEqual(0, len(self.problems))

--- a/tests/tools/test_credo.py
+++ b/tests/tools/test_credo.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 from lintreview.review import Comment, Problems
 from lintreview.tools.credo import Credo
 from unittest import TestCase
-from nose.tools import eq_
-from tests import requires_image, root_dir
+from tests import root_dir, requires_image
 
 
 class TestCredo(TestCase):
@@ -29,15 +28,17 @@ class TestCredo(TestCase):
     @requires_image('credo')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('credo')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
         fname = self.fixtures[1]
-        expected = Comment(fname, 3, 3, 'Pipe chain should start with a raw value.')
-        eq_(expected, problems[0])
-        expected = Comment(fname, 1, 1, 'Modules should have a @moduledoc tag.')
-        eq_(expected, problems[1])
+        expected = Comment(fname, 3, 3,
+                           'Pipe chain should start with a raw value.')
+        self.assertEqual(expected, problems[0])
+        expected = Comment(fname, 1, 1,
+                           'Modules should have a @moduledoc tag.')
+        self.assertEqual(expected, problems[1])

--- a/tests/tools/test_csslint.py
+++ b/tests/tools/test_csslint.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
-from lintreview.review import Problems, Comment
+from lintreview.review import Problems
 from lintreview.tools.csslint import Csslint
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -31,31 +30,32 @@ class TestCsslint(TestCase):
     @requires_image('nodejs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('nodejs')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures[1]
-        eq_(fname, problems[0].filename)
-        eq_(1, problems[0].line)
-        assert_in("Warning - Don't use IDs in selectors.", problems[0].body)
+        self.assertEqual(fname, problems[0].filename)
+        self.assertEqual(1, problems[0].line)
+        self.assertIn("Warning - Don't use IDs in selectors.",
+                      problems[0].body)
 
-        eq_(fname, problems[1].filename)
-        eq_(2, problems[1].line)
-        assert_in("Warning - Using width with padding", problems[1].body)
+        self.assertEqual(fname, problems[1].filename)
+        self.assertEqual(2, problems[1].line)
+        self.assertIn("Warning - Using width with padding", problems[1].body)
 
     @requires_image('nodejs')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
     @requires_image('nodejs')
     def test_process_files_with_config(self):
@@ -67,7 +67,8 @@ class TestCsslint(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(1, len(problems), 'Config file should lower error count.')
+        self.assertEqual(1, len(problems),
+                         'Config file should lower error count.')
 
     @requires_image('nodejs')
     def test_process_files_with_config_with_shell_injection(self):

--- a/tests/tools/test_eslint.py
+++ b/tests/tools/test_eslint.py
@@ -4,11 +4,10 @@ from unittest import TestCase
 from lintreview.review import Problems, Comment, IssueComment
 from lintreview.tools.eslint import Eslint
 import lintreview.docker as docker
-from nose.tools import eq_, ok_, assert_in, assert_not_in
 from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
-FILE_WITH_NO_ERRORS = 'tests/fixtures/eslint/no_errors.js',
+FILE_WITH_NO_ERRORS = 'tests/fixtures/eslint/no_errors.js'
 FILE_WITH_ERRORS = 'tests/fixtures/eslint/has_errors.js'
 FILE_WITH_FIXER_ERRORS = 'tests/fixtures/eslint/fixer_errors.js'
 
@@ -46,23 +45,24 @@ class TestEslint(TestCase):
 
     @requires_image('eslint')
     def test_process_files_pass(self):
-        self.tool.process_files(FILE_WITH_NO_ERRORS)
-        eq_([], self.problems.all(FILE_WITH_NO_ERRORS))
+        self.tool.process_files([FILE_WITH_NO_ERRORS])
+        actual = self.problems.all(FILE_WITH_NO_ERRORS)
+        self.assertEqual([], actual)
 
     @requires_image('eslint')
     def test_process_files_fail(self):
         self.tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all(FILE_WITH_ERRORS)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         msg = ("'foo' is assigned a value but never used. (no-unused-vars)\n"
                "'bar' is not defined. (no-undef)")
         expected = Comment(FILE_WITH_ERRORS, 2, 2, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
-        msg = ("'alert' is not defined. (no-undef)")
+        msg = "'alert' is not defined. (no-undef)"
         expected = Comment(FILE_WITH_ERRORS, 4, 4, msg)
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('eslint')
     def test_process_files__config_file_missing(self):
@@ -71,11 +71,11 @@ class TestEslint(TestCase):
                       base_path=root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config returns 1 error')
+        self.assertEqual(1, len(problems), 'Invalid config returns 1 error')
         msg = ('Your eslint config file is missing or invalid. '
                'Please ensure that `invalid-file` exists and is valid.')
         expected = [IssueComment(msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)
 
     @requires_image('eslint')
     def test_process_files__config_file_syntax_error(self):
@@ -86,16 +86,18 @@ class TestEslint(TestCase):
                       base_path=root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config returns 1 error')
-        assert_in('Your ESLint configuration is not valid', problems[0].body)
-        assert_in('YAMLException: Cannot read', problems[0].body)
+        self.assertEqual(1, len(problems), 'Invalid config returns 1 error')
+        self.assertIn('Your ESLint configuration is not valid',
+                      problems[0].body)
+        self.assertIn('YAMLException: Cannot read', problems[0].body)
 
     @requires_image('eslint')
     def test_process_files_uses_default_config(self):
         tool = Eslint(self.problems, options={}, base_path=root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all(FILE_WITH_ERRORS)
-        eq_(2, len(problems), 'With no config file there should be errors.')
+        self.assertEqual(2, len(problems),
+                         'With no config file there should be errors.')
 
     @requires_image('eslint')
     def test_process_files__invalid_config(self):
@@ -103,11 +105,13 @@ class TestEslint(TestCase):
         tool = Eslint(self.problems, options, root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config should report an error')
+        self.assertEqual(1, len(problems),
+                         'Invalid config should report an error')
         error = problems[0]
-        ok_('Your eslint configuration output the following error'
-            in error.body)
-        ok_("Cannot find module 'eslint-config-invalid-rules'" in error.body)
+        self.assertIn('Your eslint configuration output the following error',
+                      error.body)
+        self.assertIn("Cannot find module 'eslint-config-invalid-rules'",
+                      error.body)
 
     @requires_image('eslint')
     def test_process_files__missing_plugin(self):
@@ -115,12 +119,13 @@ class TestEslint(TestCase):
         tool = Eslint(self.problems, options, root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config should report an error')
+        self.assertEqual(1, len(problems),
+                         'Invalid config should report an error')
         error = problems[0]
-        ok_('Your eslint configuration output the following error'
-            in error.body)
-        ok_('ESLint couldn\'t find the plugin "eslint-plugin-nopers"'
-            in error.body)
+        self.assertIn('Your eslint configuration output the following error',
+                      error.body)
+        expected = 'ESLint couldn\'t find the plugin "eslint-plugin-nopers"'
+        self.assertIn(expected, error.body)
 
     @requires_image('eslint')
     def test_process_files__deprecated_option(self):
@@ -128,13 +133,14 @@ class TestEslint(TestCase):
         tool = Eslint(self.problems, options, root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        ok_(len(problems), 'Invalid config should report an error')
+        self.assertGreater(len(problems), 0,
+                           'Invalid config should report an error')
         error = problems[0]
-        ok_('Your eslint configuration output the following error'
-            in error.body)
-        ok_('DeprecationWarning' in error.body)
+        self.assertIn('Your eslint configuration output the following error',
+                      error.body)
+        self.assertIn('DeprecationWarning', error.body)
         style_error = problems[1]
-        assert_not_in('DeprecationWarning', style_error.body)
+        self.assertNotIn('DeprecationWarning', style_error.body)
 
     @requires_image('eslint')
     def test_process_files_with_config(self):
@@ -150,15 +156,15 @@ class TestEslint(TestCase):
                "'bar' is not defined. (no-undef)\n"
                "Missing semicolon. (semi)")
         expected = [Comment(FILE_WITH_ERRORS, 2, 2, msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)
 
     def test_has_fixer__not_enabled(self):
         tool = Eslint(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Eslint(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('eslint')
     def test_execute_fixer(self):
@@ -171,7 +177,8 @@ class TestEslint(TestCase):
 
         updated = read_and_restore_file(FILE_WITH_FIXER_ERRORS, original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('eslint')
     def test_execute_fixer__no_problems_remain(self):
@@ -186,7 +193,8 @@ class TestEslint(TestCase):
         tool.process_files([FILE_WITH_FIXER_ERRORS])
 
         read_and_restore_file(FILE_WITH_FIXER_ERRORS, original)
-        eq_(0, len(self.problems.all()), 'All errors should be autofixed')
+        self.assertEqual(0, len(self.problems.all()),
+                         'All errors should be autofixed')
 
     @requires_image('eslint')
     def test_execute__install_plugins(self):
@@ -200,11 +208,12 @@ class TestEslint(TestCase):
         tool.process_files([target])
 
         problems = self.problems.all()
-        eq_(2, len(problems), 'Should find errors')
-        assert_in('Unexpected var', problems[0].body)
+        self.assertEqual(2, len(problems), 'Should find errors')
+        self.assertIn('Unexpected var', problems[0].body)
 
-        ok_(docker.image_exists('nodejs'), 'original image is present')
-        assert_not_in('eslint-', docker.images(), 'no eslint image remains')
+        self.assertTrue(docker.image_exists('nodejs'),
+                        'original image is present')
+        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')
 
     @requires_image('eslint')
     def test_execute_fixer__install_plugins(self):
@@ -223,8 +232,9 @@ class TestEslint(TestCase):
         tool.process_files(['fixer_errors.js'])
 
         read_and_restore_file(target, original)
-        eq_(0, len(self.problems.all()), 'All errors should be autofixed')
-        assert_not_in('eslint-', docker.images(), 'no eslint image remains')
+        self.assertEqual(0, len(self.problems.all()),
+                         'All errors should be autofixed')
+        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')
 
     @requires_image('eslint')
     def test_execute__install_plugins_cleanup_image_on_failure(self):
@@ -238,8 +248,9 @@ class TestEslint(TestCase):
         tool.process_files([target])
 
         problems = self.problems.all()
-        eq_(1, len(problems))
-        assert_in('Cannot find module', problems[0].body)
+        self.assertEqual(1, len(problems))
+        self.assertIn('Cannot find module', problems[0].body)
 
-        ok_(docker.image_exists('eslint'), 'original image is present')
-        assert_not_in('eslint-', docker.images(), 'no eslint image remains')
+        self.assertTrue(docker.image_exists('eslint'),
+                        'original image is present')
+        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')

--- a/tests/tools/test_flake8.py
+++ b/tests/tools/test_flake8.py
@@ -2,15 +2,14 @@ from __future__ import absolute_import
 from lintreview.review import Problems
 from lintreview.tools.flake8 import Flake8
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import requires_image, root_dir, read_file, read_and_restore_file
 
 
 class TestFlake8(TestCase):
 
     fixtures = [
-        'tests/fixtures/pep8/no_errors.py',
-        'tests/fixtures/pep8/has_errors.py',
+        'tests/fixtures/flake8/no_errors.py',
+        'tests/fixtures/flake8/has_errors.py',
     ]
 
     def setUp(self):
@@ -27,7 +26,7 @@ class TestFlake8(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
@@ -35,36 +34,36 @@ class TestFlake8(TestCase):
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
 
-        eq_(2, problems[0].line)
-        eq_(2, problems[0].position)
-        assert_in('multiple imports on one line', problems[0].body)
+        self.assertEqual(7, problems[0].line)
+        self.assertEqual(7, problems[0].position)
+        self.assertIn('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
 
-        eq_(2, problems[0].line)
-        eq_(2, problems[0].position)
-        assert_in('multiple imports on one line', problems[0].body)
+        self.assertEqual(7, problems[0].line)
+        self.assertEqual(7, problems[0].position)
+        self.assertIn('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
     def test_process_absolute_container_path(self):
         fixtures = ['/src/' + path for path in self.fixtures]
         self.tool.process_files(fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
 
-        eq_(2, problems[0].line)
-        eq_(2, problems[0].position)
-        assert_in('multiple imports on one line', problems[0].body)
+        self.assertEqual(7, problems[0].line)
+        self.assertEqual(7, problems[0].position)
+        self.assertIn('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
     def test_execute_config_with_format(self):
@@ -79,19 +78,19 @@ class TestFlake8(TestCase):
         for issue in problems:
             assert 'W302' not in issue.body
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_process_files_two_files__python3(self):
         self.tool.options['python'] = 3
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
 
-        eq_(2, problems[0].line)
-        eq_(2, problems[0].position)
-        assert_in('multiple imports on one line', problems[0].body)
+        self.assertEqual(7, problems[0].line)
+        self.assertEqual(7, problems[0].position)
+        self.assertIn('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
     def test_config_options_and_process_file(self):
@@ -122,7 +121,7 @@ class TestFlake8(TestCase):
             '--isolated',
             self.fixtures[1]
         ]
-        eq_(set(expected), set(out))
+        self.assertEqual(set(expected), set(out))
 
     def test_make_command__config(self):
         options = {
@@ -142,15 +141,15 @@ class TestFlake8(TestCase):
             '--format', 'default',
             self.fixtures[1]
         ]
-        eq_(set(expected), set(out))
+        self.assertEqual(set(expected), set(out))
 
     def test_has_fixer__not_enabled(self):
         tool = Flake8(self.problems, {}, root_dir)
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Flake8(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('python2')
     def test_execute_fixer(self):
@@ -161,7 +160,8 @@ class TestFlake8(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('python2')
     def test_execute_fixer__fewer_problems_remain(self):
@@ -176,9 +176,9 @@ class TestFlake8(TestCase):
         assert 1 < len(self.problems.all()), 'Most errors should be fixed'
 
         text = [c.body for c in self.problems.all()]
-        assert_in("'<>' is deprecated", ' '.join(text))
+        self.assertIn("'<>' is deprecated", ' '.join(text))
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_execute_fixer__python3(self):
         options = {'fixer': True, 'python': 3}
         tool = Flake8(self.problems, options, root_dir)
@@ -188,9 +188,10 @@ class TestFlake8(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_execute_fixer__fewer_problems_remain__python3(self):
         options = {'fixer': True, 'python': 3}
         tool = Flake8(self.problems, options, root_dir)
@@ -201,7 +202,8 @@ class TestFlake8(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        assert 1 < len(self.problems.all()), 'Most errors should be fixed'
+        self.assertGreaterEqual(len(self.problems.all()), 1,
+                                'Most errors should be fixed')
 
         text = [c.body for c in self.problems.all()]
-        assert_in("'<>' is deprecated", ' '.join(text))
+        self.assertIn("'<>' is deprecated", ' '.join(text))

--- a/tests/tools/test_foodcritic.py
+++ b/tests/tools/test_foodcritic.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
+import os
 from lintreview.review import Comment, Problems
 from lintreview.tools.foodcritic import Foodcritic
 from unittest import TestCase
-from nose.tools import eq_
 from tests import root_dir, requires_image
-import os
 
 
 class TestFoodcritic(TestCase):
@@ -23,7 +22,7 @@ class TestFoodcritic(TestCase):
                                {},
                                os.path.join(root_dir, self.fixtures[0]))
         self.tool.process_files(None)
-        eq_([], self.problems.all())
+        self.assertEqual([], self.problems.all())
 
     @requires_image('ruby2')
     def test_process_cookbook_pass(self):
@@ -31,7 +30,7 @@ class TestFoodcritic(TestCase):
                                {'path': self.fixtures[0]},
                                root_dir)
         self.tool.process_files(None)
-        eq_([], self.problems.all())
+        self.assertEqual([], self.problems.all())
 
     @requires_image('ruby2')
     def test_process_cookbook_fail(self):
@@ -40,10 +39,10 @@ class TestFoodcritic(TestCase):
                                root_dir)
         self.tool.process_files(None)
         problems = self.problems.all()
-        eq_(5, len(problems))
+        self.assertEqual(5, len(problems))
 
         expected = Comment(
             'tests/fixtures/foodcritic/errors/recipes/apache2.rb', 1, 1,
             'FC007: Ensure recipe dependencies are reflected in cookbook '
             'metadata')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])

--- a/tests/tools/test_golint.py
+++ b/tests/tools/test_golint.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.golint import Golint
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from mock import patch
-from tests import requires_image, root_dir, read_file, read_and_restore_file
+from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
 class TestGolint(TestCase):
@@ -33,13 +32,13 @@ class TestGolint(TestCase):
     @requires_image('golint')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('golint')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
@@ -47,7 +46,7 @@ class TestGolint(TestCase):
             9,
             9,
             'exported function Foo should have comment or be unexported')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             fname,
@@ -55,25 +54,25 @@ class TestGolint(TestCase):
             14,
             "if block ends with a return statement, "
             "so drop this else and outdent its block")
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('golint')
     def test_process_files_two_files(self):
         self.tool.process_files([self.fixtures[0], self.fixtures[1]])
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
     @requires_image('golint')
     def test_process_files_in_different_packages(self):
         self.tool.process_files([self.fixtures[1], self.fixtures[2]])
 
         problems = self.problems.all()
-        eq_(3, len(problems))
-        eq_(2, len(self.problems.all(self.fixtures[1])))
-        eq_(1, len(self.problems.all(self.fixtures[2])))
+        self.assertEqual(3, len(problems))
+        self.assertEqual(2, len(self.problems.all(self.fixtures[1])))
+        self.assertEqual(1, len(self.problems.all(self.fixtures[2])))
 
     @requires_image('golint')
     @patch('lintreview.docker.run')
@@ -99,20 +98,20 @@ class TestGolint(TestCase):
         }
         tool = Golint(self.problems, config, root_dir)
         tool.process_files([self.fixtures[1]])
-        eq_(2, len(self.problems))
+        self.assertEqual(2, len(self.problems))
 
     @requires_image('golint')
     def test_process_files_with_ignores(self):
         config = {
             'min_confidence': 0.3,
             'ignore': [
-                'exported function \w+ should have comment',
-                'has_errors\.go'
+                r'exported function \w+ should have comment',
+                r'has_errors\.go'
             ]
         }
         tool = Golint(self.problems, config, root_dir)
         tool.process_files([self.fixtures[1]])
-        eq_(0, len(self.problems))
+        self.assertEqual(0, len(self.problems))
 
     @requires_image('golint')
     def test_process_files_with_invalid_ignore_pattern(self):
@@ -125,16 +124,16 @@ class TestGolint(TestCase):
         tool = Golint(self.problems, config, root_dir)
         tool.process_files([self.fixtures[1]])
         problems = self.problems.all()
-        assert_in('Invalid golint ignore rule `(.*`', problems[0].body)
-        assert_in('exported function', problems[1].body)
+        self.assertIn('Invalid golint ignore rule `(.*`', problems[0].body)
+        self.assertIn('exported function', problems[1].body)
 
     def test_has_fixer__not_enabled(self):
         tool = Golint(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Golint(self.problems, {'fixer': True})
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('golint')
     def test_execute_fixer(self):
@@ -145,4 +144,5 @@ class TestGolint(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')

--- a/tests/tools/test_goodcheck.py
+++ b/tests/tools/test_goodcheck.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 from lintreview.review import Comment, Problems
 from lintreview.tools.goodcheck import Goodcheck
 from tests import (
-    root_dir, requires_image
+    root_dir,
+    requires_image,
 )
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 
 
 class TestGoodcheck(TestCase):
@@ -29,7 +29,7 @@ class TestGoodcheck(TestCase):
     @requires_image('ruby2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('ruby2')
     def test_process_files__one_file_fail(self):
@@ -41,17 +41,17 @@ class TestGoodcheck(TestCase):
             2,
             2,
             'Write "GitHub", not "Github"')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('ruby2')
     def test_process_files__two_files(self):
         self.tool.process_files(self.fixtures)
 
         linty_filename = self.fixtures[1]
-        eq_(2, len(self.problems.all(linty_filename)))
+        self.assertEqual(2, len(self.problems.all(linty_filename)))
 
         freshly_laundered_filename = self.fixtures[0]
-        eq_([], self.problems.all(freshly_laundered_filename))
+        self.assertEqual([], self.problems.all(freshly_laundered_filename))
 
     @requires_image('ruby2')
     def test_process_specific_rules(self):
@@ -68,7 +68,7 @@ class TestGoodcheck(TestCase):
             3,
             3,
             'Use hostnames, not RFC 1918 IPs')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('ruby2')
     def test_add_justifications_to_comments(self):
@@ -81,5 +81,5 @@ class TestGoodcheck(TestCase):
 
         problem_body = self.problems.all(self.fixtures[1])[1].body
 
-        assert_in(" - Unless you can't find another way", problem_body)
-        assert_in(" - some other reason", problem_body)
+        self.assertIn(" - Unless you can't find another way", problem_body)
+        self.assertIn(" - some other reason", problem_body)

--- a/tests/tools/test_gpg.py
+++ b/tests/tools/test_gpg.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from unittest import TestCase
 from lintreview.review import Problems
 from lintreview.tools.gpg import Gpg
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -14,7 +13,7 @@ class TestGpg(TestCase):
 
     @requires_image('gpg')
     def test_check_dependencies(self):
-        eq_(True, self.tool.check_dependencies())
+        self.assertEqual(True, self.tool.check_dependencies())
 
     @requires_image('gpg')
     def test_execute(self):
@@ -22,4 +21,4 @@ class TestGpg(TestCase):
 
         comments = self.problems.all()
         if len(comments):
-            assert_in('gpg signature', comments[0].body)
+            self.assertIn('gpg signature', comments[0].body)

--- a/tests/tools/test_jshint.py
+++ b/tests/tools/test_jshint.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.jshint import Jshint
 from unittest import TestCase
-from nose.tools import eq_
 from tests import root_dir, requires_image
 
 
@@ -32,43 +31,43 @@ class TestJshint(TestCase):
     @requires_image('nodejs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('nodejs')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(fname, 1, 1,
                            'Missing name in function declaration.')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(fname, 4, 4, "Missing semicolon.")
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('nodejs')
     def test_process_files__multiple_error(self):
         self.tool.process_files([self.fixtures[2]])
         problems = self.problems.all(self.fixtures[2])
-        eq_(6, len(problems))
+        self.assertEqual(6, len(problems))
 
         fname = self.fixtures[2]
         expected = Comment(fname, 9, 9, "Missing semicolon.")
-        eq_(expected, problems[2])
+        self.assertEqual(expected, problems[2])
 
         expected = Comment(fname, 5, 5, "'go' is not defined.")
-        eq_(expected, problems[4])
+        self.assertEqual(expected, problems[4])
 
     @requires_image('nodejs')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
     @requires_image('nodejs')
     def test_process_files_with_config(self):
@@ -80,7 +79,8 @@ class TestJshint(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(3, len(problems), 'Config file should lower error count.')
+        self.assertEqual(3, len(problems),
+                         'Config file should lower error count.')
 
     def test_create_command__with_path_based_standard(self):
         config = {
@@ -94,4 +94,4 @@ class TestJshint(TestCase):
             'some/file.js'
         ]
         assert 'jshint' in result[0], 'jshint is in command name'
-        eq_(result[1:], expected)
+        self.assertEqual(result[1:], expected)

--- a/tests/tools/test_jsonlint.py
+++ b/tests/tools/test_jsonlint.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.jsonlint import Jsonlint
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -28,56 +27,56 @@ class TestJsonlint(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures[1]
 
         msg = ("Warning: String literals must use "
                "double quotation marks in strict JSON")
         expected = Comment(fname, 2, 2, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         msg = ("Warning: JSON does not allow identifiers "
                "to be used as strings: u'three'\n"
                "Warning: Strict JSON does not allow a final comma "
                "in an object (dictionary) literal")
-        eq_(3, problems[1].line)
-        eq_(3, problems[1].position)
-        assert_in("Warning: JSON does not allow identifiers",
-                  problems[1].body)
-        assert_in("Warning: Strict JSON does not allow a final comma",
-                  problems[1].body)
+        self.assertEqual(3, problems[1].line)
+        self.assertEqual(3, problems[1].position)
+        self.assertIn("Warning: JSON does not allow identifiers",
+                      problems[1].body)
+        self.assertIn("Warning: Strict JSON does not allow a final comma",
+                      problems[1].body)
 
     @requires_image('python2')
     def test_process_files_three_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         fname = self.fixtures[1]
         problems = self.problems.all(fname)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         msg = ("Warning: String literals must use "
                "double quotation marks in strict JSON")
         expected = Comment(fname, 2, 2, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
-        eq_(3, problems[1].line)
-        eq_(3, problems[1].position)
-        assert_in('JSON does not allow identifiers to be used',
-                  problems[1].body)
+        self.assertEqual(3, problems[1].line)
+        self.assertEqual(3, problems[1].position)
+        self.assertIn('JSON does not allow identifiers to be used',
+                      problems[1].body)
 
         fname = self.fixtures[2]
         problems = self.problems.all(fname)
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
-        eq_(1, problems[0].line)
-        eq_(1, problems[0].position)
-        assert_in('Unknown identifier', problems[0].body)
+        self.assertEqual(1, problems[0].line)
+        self.assertEqual(1, problems[0].position)
+        self.assertIn('Unknown identifier', problems[0].body)

--- a/tests/tools/test_ktlint.py
+++ b/tests/tools/test_ktlint.py
@@ -4,9 +4,8 @@ from unittest import TestCase
 from lintreview.review import Problems, Comment
 from lintreview.tools.ktlint import Ktlint
 from tests import (
-    root_dir, requires_image, read_file, read_and_restore_file
+    root_dir, read_file, read_and_restore_file, requires_image
 )
-from nose.tools import eq_
 
 
 class TestKtlint(TestCase):
@@ -38,19 +37,20 @@ class TestKtlint(TestCase):
     def test_process_files_pass(self):
         file_no_errors = self.fixtures[0]
         self.tool.process_files(file_no_errors)
-        eq_([], self.problems.all(file_no_errors))
+        self.assertEqual([], self.problems.all(file_no_errors))
 
     @requires_image('ktlint')
     def test_process_files_fail(self):
         file_has_errors = self.fixtures[1]
         self.tool.process_files([file_has_errors])
         problems = self.problems.all(file_has_errors)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
-        expected = Comment(file_has_errors, 1, 1, 'Redundant "toString()" call in string template')
-        eq_(expected, problems[0])
+        expected = Comment(file_has_errors, 1, 1,
+                           'Redundant "toString()" call in string template')
+        self.assertEqual(expected, problems[0])
         expected = Comment(file_has_errors, 2, 2, 'Redundant curly braces')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('ktlint')
     def test_process_files_with_android(self):
@@ -58,48 +58,59 @@ class TestKtlint(TestCase):
         tool = Ktlint(self.problems, {'android': True}, root_dir)
         tool.process_files([file_android_has_errors])
         problems = self.problems.all(file_android_has_errors)
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
         expected = Comment(file_android_has_errors, 1, 1,
-                           'class AndroidActivity should be declared in a file named ' +
-                           'AndroidActivity.kt (cannot be auto-corrected)')
-        eq_(expected, problems[0])
+                           ('class AndroidActivity should be declared in a '
+                            'file named AndroidActivity.kt (cannot be '
+                            'auto-corrected)'))
+        self.assertEqual(expected, problems[0])
         expected = Comment(file_android_has_errors, 9, 9,
                            'Wildcard import (cannot be auto-corrected)')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
         # Android options should lint max line length in a file
         expected = Comment(file_android_has_errors, 51, 51,
-                           'Exceeded max line length (100) (cannot be auto-corrected)')
-        eq_(expected, problems[2])
+                           ('Exceeded max line length (100) '
+                            '(cannot be auto-corrected)'))
+        self.assertEqual(expected, problems[2])
 
     @requires_image('ktlint')
     def test_process_files_multiple_files(self):
         self.tool.process_files(self.fixtures)
-        eq_([], self.problems.all(self.fixtures[0]))
-        eq_(2, len(self.problems.all(self.fixtures[1])))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
+        self.assertEqual(2, len(self.problems.all(self.fixtures[1])))
         # Without android options should only display 2 errors
-        eq_(2, len(self.problems.all(self.fixtures[2])))
+        self.assertEqual(2, len(self.problems.all(self.fixtures[2])))
 
     def test_has_fixer__not_enabled(self):
         tool = Ktlint(self.problems, {}, root_dir)
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Ktlint(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('ktlint')
     def test_process_files__with_ruleset(self):
-        tool = Ktlint(self.problems, {'ruleset': '/path/to/custom/rulseset.jar'}, root_dir)
-        eq_(['ktlint', '--color', '--reporter=checkstyle', '-R', '/path/to/custom/rulseset.jar'],
-            tool._create_command())
+        tool = Ktlint(self.problems,
+                      {'ruleset': '/path/to/custom/rulseset.jar'}, root_dir)
+        self.assertEqual(['ktlint',
+                          '--color',
+                          '--reporter=checkstyle',
+                          '-R',
+                          '/path/to/custom/rulseset.jar'],
+                         tool._create_command())
 
     @requires_image('ktlint')
     def test_process_files__valid_config(self):
         editor_config = 'tests/fixtures/ktlint/.editorconfig'
         tool = Ktlint(self.problems, {'config': editor_config}, root_dir)
-        eq_(['ktlint', '--color', '--reporter=checkstyle', '--editorconfig=', editor_config],
-            tool._create_command())
+        self.assertEqual(['ktlint',
+                         '--color',
+                          '--reporter=checkstyle',
+                          '--editorconfig=',
+                          editor_config],
+                         tool._create_command())
 
     @requires_image('ktlint')
     def test_execute_fixer(self):
@@ -110,4 +121,5 @@ class TestKtlint(TestCase):
 
         updated = read_and_restore_file(target, original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')

--- a/tests/tools/test_luacheck.py
+++ b/tests/tools/test_luacheck.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.luacheck import Luacheck
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -32,13 +31,13 @@ class Testluacheck(TestCase):
     @requires_image('luacheck')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('luacheck')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
@@ -46,16 +45,16 @@ class Testluacheck(TestCase):
             5,
             5,
             '(E011) expected \'=\' near \'+\'')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('luacheck')
     def test_process_files_three_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[2])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures[2]
         expected = Comment(
@@ -64,7 +63,7 @@ class Testluacheck(TestCase):
             3,
             '(W213) unused loop variable \'a\'\n'
             '(W113) accessing undefined variable \'sometable\'')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('luacheck')
     def test_process_files_with_config(self):
@@ -75,7 +74,8 @@ class Testluacheck(TestCase):
         tool.process_files(self.fixtures)
 
         problems = self.problems.all(self.fixtures[2])
-        eq_(1, len(problems), 'Config file should lower error count.')
+        self.assertEqual(1, len(problems),
+                         'Config file should lower error count.')
 
     @requires_image('luacheck')
     def test_process_files_with_missing_config(self):
@@ -86,8 +86,8 @@ class Testluacheck(TestCase):
         tool.process_files(self.fixtures)
 
         problems = self.problems.all()
-        eq_(1, len(problems),
-            "Couldn't load configuration from")
-        assert_in("Couldn't", problems[0].body)
-        assert_in("configuration", problems[0].body)
-        assert_in("not_a_file", problems[0].body)
+        self.assertEqual(1, len(problems),
+                         "Couldn't load configuration from")
+        self.assertIn("Couldn't", problems[0].body)
+        self.assertIn("configuration", problems[0].body)
+        self.assertIn("not_a_file", problems[0].body)

--- a/tests/tools/test_pep8.py
+++ b/tests/tools/test_pep8.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.pep8 import Pep8
 from unittest import TestCase
-from nose.tools import eq_, assert_in, assert_not_in
 from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
@@ -27,57 +26,57 @@ class TestPep8(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(6, len(problems))
+        self.assertEqual(6, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(fname, 2, 2, 'E401 multiple imports on one line')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(fname, 11, 11, "W603 '<>' is deprecated, use '!='")
-        eq_(expected, problems[5])
+        self.assertEqual(expected, problems[5])
 
     @requires_image('python2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(6, len(problems))
+        self.assertEqual(6, len(problems))
         expected = Comment(self.fixtures[1], 2, 2,
                            'E401 multiple imports on one line')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(self.fixtures[1], 11, 11,
                            "W603 '<>' is deprecated, use '!='")
-        eq_(expected, problems[5])
+        self.assertEqual(expected, problems[5])
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_process_files_two_files__python3(self):
         self.tool.options['python'] = 3
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
 
-        eq_(2, problems[0].line)
-        eq_(2, problems[0].position)
-        assert_in('multiple imports on one line', problems[0].body)
+        self.assertEqual(2, problems[0].line)
+        self.assertEqual(2, problems[0].position)
+        self.assertIn('multiple imports on one line', problems[0].body)
 
     @requires_image('python2')
     def test_process_absolute_container_path(self):
         fixtures = ['/src/' + path for path in self.fixtures]
         self.tool.process_files(fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
         assert len(problems) >= 6
@@ -90,10 +89,10 @@ class TestPep8(TestCase):
         self.tool = Pep8(self.problems, options, root_dir)
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(4, len(problems))
+        self.assertEqual(4, len(problems))
         for p in problems:
-            assert_not_in('E2', p.body)
-            assert_not_in('W603', p.body)
+            self.assertNotIn('E2', p.body)
+            self.assertNotIn('W603', p.body)
 
     @requires_image('python2')
     def test_process_files__line_length(self):
@@ -103,10 +102,10 @@ class TestPep8(TestCase):
         self.tool = Pep8(self.problems, options, root_dir)
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(10, len(problems))
+        self.assertEqual(10, len(problems))
         expected = Comment(self.fixtures[1], 1, 1,
                            'E501 line too long (23 > 10 characters)')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('python2')
     def test_process_files__select(self):
@@ -116,17 +115,17 @@ class TestPep8(TestCase):
         self.tool = Pep8(self.problems, options, root_dir)
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
         for p in problems:
-            assert_in('W603', p.body)
+            self.assertIn('W603', p.body)
 
     def test_has_fixer__not_enabled(self):
         tool = Pep8(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Pep8(self.problems, {'fixer': True})
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('python2')
     def test_execute_fixer(self):
@@ -137,7 +136,8 @@ class TestPep8(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('python2')
     def test_execute_fixer__options(self):
@@ -152,7 +152,8 @@ class TestPep8(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('python2')
     def test_execute_fixer__fewer_problems_remain(self):
@@ -164,11 +165,10 @@ class TestPep8(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        assert len(self.problems.all()) > 0, 'Most errors should be fixed'
-        text = [c.body for c in self.problems.all()]
-        assert_in("'<>' is deprecated", ' '.join(text))
+        self.assertGreaterEqual(len(self.problems.all()), 0,
+                                'Most errors should be fixed')
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_execute_fixer__python3(self):
         options = {'fixer': True, 'python': 3}
         tool = Pep8(self.problems, options, root_dir)
@@ -178,9 +178,10 @@ class TestPep8(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
-    @requires_image('python3')
+    @requires_image('python2')
     def test_execute_fixer__fewer_problems_remain__python3(self):
         options = {'fixer': True, 'python': 3}
         tool = Pep8(self.problems, options, root_dir)
@@ -191,7 +192,8 @@ class TestPep8(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        assert 1 < len(self.problems.all()), 'Most errors should be fixed'
+        self.assertLessEqual(1, len(self.problems.all()),
+                             'Most errors should be fixed')
 
         text = [c.body for c in self.problems.all()]
-        assert_in("'<>' is deprecated", ' '.join(text))
+        self.assertIn("'<>' is deprecated", ' '.join(text))

--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.phpcs import Phpcs
 from unittest import TestCase
-from nose.tools import eq_, ok_
-from tests import requires_image, root_dir, read_file, read_and_restore_file
+from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
 class Testphpcs(TestCase):
@@ -31,13 +30,13 @@ class Testphpcs(TestCase):
     @requires_image('phpcs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('phpcs')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
@@ -45,23 +44,23 @@ class Testphpcs(TestCase):
             14,
             14,
             'Opening brace should be on a new line')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             fname,
             16,
             16,
             "Spaces must be used to indent lines; tabs are not allowed")
-        eq_(expected, problems[2])
+        self.assertEqual(expected, problems[2])
 
     @requires_image('phpcs')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
     @requires_image('phpcs')
     def test_process_files__with_config(self):
@@ -73,7 +72,8 @@ class Testphpcs(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(3, len(problems), 'Changing standards changes error counts')
+        self.assertEqual(3, len(problems),
+                         'Changing standards changes error counts')
 
     @requires_image('phpcs')
     def test_process_files__with_ignore(self):
@@ -86,7 +86,8 @@ class Testphpcs(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(0, len(problems), 'ignore option should exclude files')
+        self.assertEqual(0, len(problems),
+                         'ignore option should exclude files')
 
     @requires_image('phpcs')
     def test_process_files__with_exclude(self):
@@ -99,7 +100,8 @@ class Testphpcs(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(1, len(problems), 'exclude option should reduce errors.')
+        self.assertEqual(1, len(problems),
+                         'exclude option should reduce errors.')
 
     @requires_image('phpcs')
     def test_process_files__with_invalid_exclude(self):
@@ -111,11 +113,13 @@ class Testphpcs(TestCase):
         tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all()
-        eq_(1, len(problems), 'A failure comment should be logged.')
+        self.assertEqual(1, len(problems),
+                         'A failure comment should be logged.')
 
         error = problems[0].body
-        ok_('Your PHPCS configuration output the following error' in error)
-        ok_('Derpity.Derp' in error)
+        self.assertIn('Your PHPCS configuration output the following error',
+                      error)
+        self.assertIn('Derpity.Derp', error)
 
     def test_create_command__with_builtin_standard(self):
         config = {
@@ -132,7 +136,7 @@ class Testphpcs(TestCase):
             '--tab-width=4',
             '/src/some/file.php'
         ]
-        eq_(result, expected)
+        self.assertEqual(result, expected)
 
     def test_create_command__with_path_based_standard(self):
         config = {
@@ -149,7 +153,7 @@ class Testphpcs(TestCase):
             '--tab-width=4',
             '/src/some/file.php'
         ]
-        eq_(result, expected)
+        self.assertEqual(result, expected)
 
     def test_create_command__ignore_option_as_list(self):
         config = {
@@ -169,15 +173,15 @@ class Testphpcs(TestCase):
             '--extensions=php,ctp',
             '/src/some/file.php'
         ]
-        eq_(result, expected)
+        self.assertEqual(result, expected)
 
     def test_has_fixer__not_enabled(self):
         tool = Phpcs(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Phpcs(self.problems, {'fixer': True})
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('phpcs')
     def test_execute_fixer(self):
@@ -188,7 +192,8 @@ class Testphpcs(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('phpcs')
     def test_execute_fixer__no_problems_remain(self):
@@ -200,4 +205,5 @@ class Testphpcs(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        eq_(0, len(self.problems.all()), 'All errors should be autofixed')
+        self.assertEqual(0, len(self.problems.all()),
+                         'All errors should be autofixed')

--- a/tests/tools/test_puppet.py
+++ b/tests/tools/test_puppet.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 from lintreview.review import Problems, Comment
 from lintreview.tools.puppet import Puppet
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from operator import attrgetter
-from tests import root_dir, requires_image, read_file, read_and_restore_file
+from tests import requires_image, root_dir, read_file, read_and_restore_file
 
 
 class TestPuppet(TestCase):
@@ -27,7 +26,7 @@ class TestPuppet(TestCase):
     @requires_image('ruby2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('ruby2')
     def test_process_files__one_file_fail(self):
@@ -40,17 +39,17 @@ class TestPuppet(TestCase):
         ]
 
         problems = sorted(self.problems.all(filename), key=attrgetter('line'))
-        eq_(expected_problems, problems)
+        self.assertEqual(expected_problems, problems)
 
     @requires_image('ruby2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
         linty_filename = self.fixtures[1]
-        eq_(3, len(self.problems.all(linty_filename)))
+        self.assertEqual(3, len(self.problems.all(linty_filename)))
 
         freshly_laundered_filename = self.fixtures[0]
-        eq_([], self.problems.all(freshly_laundered_filename))
+        self.assertEqual([], self.problems.all(freshly_laundered_filename))
 
     @requires_image('ruby2')
     def test_process_files__with_config(self):
@@ -60,16 +59,16 @@ class TestPuppet(TestCase):
         tool = Puppet(self.problems, config)
         tool.process_files([self.fixtures[1]])
 
-        eq_([], self.problems.all(self.fixtures[1]),
-            'Config file should cause no errors on has_errors.pp')
+        self.assertEqual([], self.problems.all(self.fixtures[1]),
+                         'Config file should cause no errors on has_errors.pp')
 
     def test_has_fixer__not_enabled(self):
         tool = Puppet(self.problems, {}, root_dir)
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Puppet(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('ruby2')
     def test_execute_fixer(self):
@@ -80,7 +79,8 @@ class TestPuppet(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('ruby2')
     def test_execute_fixer__fewer_problems_remain(self):
@@ -92,8 +92,9 @@ class TestPuppet(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        eq_(1, len(self.problems.all()), 'Most errors should be fixed')
-        assert_in('autoload module layout', self.problems.all()[0].body)
+        self.assertEqual(1, len(self.problems.all()),
+                         'Most errors should be fixed')
+        self.assertIn('autoload module layout', self.problems.all()[0].body)
 
     @requires_image('ruby2')
     def test_execute_fixer__fixer_ignore(self):
@@ -108,8 +109,10 @@ class TestPuppet(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        eq_(2, len(self.problems.all()), 'Most errors should be fixed')
+        self.assertEqual(2, len(self.problems.all()),
+                         'Most errors should be fixed')
 
         problems = sorted(self.problems.all(), key=attrgetter('line'))
-        assert_in('ERROR:foo not in autoload module layout', problems[0].body)
-        assert_in('WARNING:quoted boolean value', problems[1].body)
+        self.assertIn('ERROR:foo not in autoload module layout',
+                      problems[0].body)
+        self.assertIn('WARNING:quoted boolean value', problems[1].body)

--- a/tests/tools/test_py3k.py
+++ b/tests/tools/test_py3k.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from unittest import TestCase
-from nose.tools import eq_
 from lintreview.review import Problems, Comment
 from lintreview.tools.py3k import Py3k
 from tests import root_dir, requires_image
@@ -27,16 +26,16 @@ class TestPy3k(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures.no_errors])
-        eq_([], self.problems.all(self.fixtures.no_errors))
+        self.assertEqual([], self.problems.all(self.fixtures.no_errors))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures.has_errors])
         problems = self.problems.all(self.fixtures.has_errors)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures.has_errors
-        eq_([
+        self.assertEqual([
             Comment(fname, 6, 6, 'E1601 print statement used'),
             Comment(fname, 11, 11,
                     'W1638 range built-in referenced when not iterating')
@@ -47,7 +46,7 @@ class TestPy3k(TestCase):
         tool = Py3k(self.problems, {'ignore': 'W1638,E1601'}, root_dir)
         tool.process_files([self.fixtures.has_errors])
         problems = self.problems.all(self.fixtures.has_errors)
-        eq_(0, len(problems))
+        self.assertEqual(0, len(problems))
 
     @requires_image('python2')
     def test_process_files__config_option_list(self):
@@ -56,20 +55,20 @@ class TestPy3k(TestCase):
                     root_dir)
         tool.process_files([self.fixtures.has_errors])
         problems = self.problems.all(self.fixtures.has_errors)
-        eq_(0, len(problems))
+        self.assertEqual(0, len(problems))
 
     @requires_image('python2')
     def test_process_files_two_files(self):
         self.tool.process_files([self.fixtures.no_errors,
                                  self.fixtures.has_errors])
 
-        eq_([], self.problems.all(self.fixtures.no_errors))
+        self.assertEqual([], self.problems.all(self.fixtures.no_errors))
 
         problems = self.problems.all(self.fixtures.has_errors)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures.has_errors
-        eq_([
+        self.assertEqual([
             Comment(fname, 6, 6, 'E1601 print statement used'),
             Comment(fname, 11, 11,
                     'W1638 range built-in referenced when not iterating')

--- a/tests/tools/test_remarklint.py
+++ b/tests/tools/test_remarklint.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from lintreview.review import Problems
 from lintreview.tools.remarklint import Remarklint
 from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, read_file, read_and_restore_file, requires_image
 
 
@@ -27,15 +26,15 @@ class TestRemarklint(TestCase):
     @requires_image('nodejs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('nodejs')
     def test_process_files__one_file_file(self):
         self.tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all()
-        eq_(2, len(problems))
-        assert_in('Incorrect list-item', problems[0].body)
+        self.assertEqual(2, len(problems))
+        self.assertIn('Incorrect list-item', problems[0].body)
 
     @requires_image('nodejs')
     def test_process_files__missing_plugin(self):
@@ -50,19 +49,19 @@ class TestRemarklint(TestCase):
         with open(config, 'w') as f:
             f.write(original)
         problems = self.problems.all()
-        eq_(1, len(problems), 'Should have an error')
-        assert_in('unknown-preset', problems[0].body)
+        self.assertEqual(1, len(problems), 'Should have an error')
+        self.assertIn('unknown-preset', problems[0].body)
 
     def test_process_files__config(self):
         pass
 
     def test_has_fixer__not_enabled(self):
         tool = Remarklint(self.problems)
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Remarklint(self.problems, {'fixer': True})
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('nodejs')
     def test_execute_fixer(self):
@@ -74,4 +73,5 @@ class TestRemarklint(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(1, len(self.problems.all()), 'Fewer errors should be recorded')
+        self.assertEqual(1, len(self.problems.all()),
+                         'Fewer errors should be recorded')

--- a/tests/tools/test_rubocop.py
+++ b/tests/tools/test_rubocop.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Comment, Problems
 from lintreview.tools.rubocop import Rubocop
 from tests import (
-    root_dir, requires_image, read_file, read_and_restore_file
+    root_dir, read_file, read_and_restore_file, requires_image
 )
-from unittest import TestCase
-from nose.tools import eq_, assert_in
 
 
 class TestRubocop(TestCase):
@@ -28,7 +28,7 @@ class TestRubocop(TestCase):
     @requires_image('ruby2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('ruby2')
     def test_process_files__one_file_fail(self):
@@ -40,17 +40,17 @@ class TestRubocop(TestCase):
             4,
             4,
             'C: Trailing whitespace detected.')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('ruby2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
         linty_filename = self.fixtures[1]
-        eq_(2, len(self.problems.all(linty_filename)))
+        self.assertEqual(2, len(self.problems.all(linty_filename)))
 
         freshly_laundered_filename = self.fixtures[0]
-        eq_([], self.problems.all(freshly_laundered_filename))
+        self.assertEqual([], self.problems.all(freshly_laundered_filename))
 
     @requires_image('ruby2')
     def test_process_files_one_file_fail_display_cop_names(self):
@@ -67,7 +67,7 @@ class TestRubocop(TestCase):
             4,
             4,
             'C: Layout/TrailingWhitespace: Trailing whitespace detected.')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('ruby2')
     def test_process_files_one_file_fail_display_cop_names__bool(self):
@@ -84,15 +84,15 @@ class TestRubocop(TestCase):
             4,
             4,
             'C: Layout/TrailingWhitespace: Trailing whitespace detected.')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     def test_has_fixer__not_enabled(self):
         tool = Rubocop(self.problems, {}, root_dir)
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Rubocop(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('ruby2')
     def test_execute_fixer(self):
@@ -103,7 +103,8 @@ class TestRubocop(TestCase):
 
         updated = read_and_restore_file(self.fixtures[1], original)
         assert original != updated, 'File content should change.'
-        eq_(0, len(self.problems.all()), 'No errors should be recorded')
+        self.assertEqual(0, len(self.problems.all()),
+                         'No errors should be recorded')
 
     @requires_image('ruby2')
     def test_execute_fixer__fewer_problems_remain(self):
@@ -115,5 +116,6 @@ class TestRubocop(TestCase):
         tool.process_files(self.fixtures)
 
         read_and_restore_file(self.fixtures[1], original)
-        eq_(1, len(self.problems.all()), 'Most errors should be fixed')
-        assert_in('too long', self.problems.all()[0].body)
+        self.assertEqual(1, len(self.problems.all()),
+                         'Most errors should be fixed')
+        self.assertIn('too long', self.problems.all()[0].body)

--- a/tests/tools/test_sasslint.py
+++ b/tests/tools/test_sasslint.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Problems, Comment
 from lintreview.tools.sasslint import Sasslint
-from unittest import TestCase
-from nose.tools import eq_
 from tests import root_dir, requires_image
 
 
@@ -33,31 +33,31 @@ class TestSasslint(TestCase):
     @requires_image('nodejs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('nodejs')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
         fname = self.fixtures[1]
-        error = ("Mixins should come before declarations"
-                 " (mixins-before-declarations)")
+        error = ("Mixins should come before declarations "
+                 "(mixins-before-declarations)")
         expected = Comment(fname, 4, 4, error)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('nodejs')
     def test_process_files__multiple_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
         problems = self.problems.all(self.fixtures[2])
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
     @requires_image('nodejs')
     def test_process_files_with_config_from_evil_jerk(self):
@@ -81,4 +81,5 @@ class TestSasslint(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(0, len(problems), 'Config file should lower error count.')
+        self.assertEqual(0, len(problems),
+                         'Config file should lower error count.')

--- a/tests/tools/test_shellcheck.py
+++ b/tests/tools/test_shellcheck.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Problems, Comment
 from lintreview.tools.shellcheck import Shellcheck
-from unittest import TestCase
-from nose.tools import eq_
 from tests import root_dir, requires_image
 
 
@@ -38,22 +38,22 @@ class Testshellcheck(TestCase):
     @requires_image('shellcheck')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('shellcheck')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
         fname = self.fixtures[1]
         expected = Comment(
             fname,
-            5,
+            3,
             3,
             'a is referenced but not assigned.\nDouble quote to prevent '
             'globbing and word splitting.')
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         expected = Comment(
             fname,
@@ -61,24 +61,24 @@ class Testshellcheck(TestCase):
             4,
             'BASE appears unused. Verify it or export it.\n'
             'Use $(..) instead of legacy \`..\`.')
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
         expected = Comment(
             fname,
             6,
             6,
-            'The order of the 2>&1 and the redirect matters. The 2>&1 has to '
-            'be last.')
-        eq_(expected, problems[2])
+            ("The order of the 2>&1 and the redirect matters. "
+             "The 2>&1 has to be last."))
+        self.assertEqual(expected, problems[2])
 
     @requires_image('shellcheck')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
     @requires_image('shellcheck')
     def test_process_files_with_config(self):
@@ -91,4 +91,5 @@ class Testshellcheck(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        eq_(2, len(problems), 'Changing standards changes error counts')
+        self.assertEqual(2, len(problems),
+                         'Changing standards changes error counts')

--- a/tests/tools/test_standardjs.py
+++ b/tests/tools/test_standardjs.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 from lintreview.review import Problems, Comment
 from lintreview.tools.standardjs import Standardjs
-from nose.tools import eq_
 from tests import root_dir, requires_image
-
 
 FILE_WITH_NO_ERRORS = 'tests/fixtures/standardjs/no_errors.js',
 FILE_WITH_ERRORS = 'tests/fixtures/standardjs/has_errors.js'
@@ -31,21 +29,21 @@ class TestStandardjs(TestCase):
     @requires_image('nodejs')
     def test_process_files_pass(self):
         self.tool.process_files(FILE_WITH_NO_ERRORS)
-        eq_([], self.problems.all(FILE_WITH_NO_ERRORS))
+        self.assertEqual([], self.problems.all(FILE_WITH_NO_ERRORS))
 
     @requires_image('nodejs')
     def test_process_files_fail(self):
         self.tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all(FILE_WITH_ERRORS)
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         msg = ("'foo' is assigned a value but never used.\n"
                "'bar' is not defined.")
         expected = Comment(FILE_WITH_ERRORS, 2, 2, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         msg = ("'alert' is not defined.\n"
                'Strings must use singlequote.\n'
                'Extra semicolon.')
         expected = Comment(FILE_WITH_ERRORS, 4, 4, msg)
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])

--- a/tests/tools/test_stylelint.py
+++ b/tests/tools/test_stylelint.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Problems, Comment
 from lintreview.tools.stylelint import Stylelint
-from unittest import TestCase
-from nose.tools import eq_, assert_in
-from tests import root_dir, read_file, read_and_restore_file, requires_image
+from tests import requires_image, root_dir, read_file, read_and_restore_file
 
 
 class TestStylelint(TestCase):
@@ -35,30 +35,31 @@ class TestStylelint(TestCase):
     @requires_image('nodejs')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('nodejs')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         fname = self.fixtures[1]
-        error = 'Unexpected unknown at-rule "@include" (at-rule-no-unknown) [error]'
+        error = ('Unexpected unknown at-rule "@include" '
+                 '(at-rule-no-unknown) [error]')
         expected = Comment(fname, 2, 2, error)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('nodejs')
     def test_process_files__multiple_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
         problems = self.problems.all(self.fixtures[2])
-        eq_(2, len(problems))
+        self.assertEqual(2, len(problems))
 
     @requires_image('nodejs')
     def test_process_files_with_config(self):
@@ -70,7 +71,8 @@ class TestStylelint(TestCase):
         tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all()
-        eq_(6, len(problems), 'Config file should change error count')
+        self.assertEqual(6, len(problems),
+                         'Config file should change error count')
 
     @requires_image('nodejs')
     def test_process_files_with_invalid_config(self):
@@ -81,18 +83,19 @@ class TestStylelint(TestCase):
         tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all()
-        eq_(1, len(problems), 'Should capture missing config error')
+        self.assertEqual(1, len(problems),
+                         'Should capture missing config error')
 
-        assert_in('Your configuration file', problems[0].body)
-        assert_in('ENOENT', problems[0].body)
+        self.assertIn('Your configuration file', problems[0].body)
+        self.assertIn('ENOENT', problems[0].body)
 
     def test_has_fixer__not_enabled(self):
         tool = Stylelint(self.problems, {})
-        eq_(False, tool.has_fixer())
+        self.assertEqual(False, tool.has_fixer())
 
     def test_has_fixer__enabled(self):
         tool = Stylelint(self.problems, {'fixer': True}, root_dir)
-        eq_(True, tool.has_fixer())
+        self.assertEqual(True, tool.has_fixer())
 
     @requires_image('nodejs')
     def test_execute_fixer(self):

--- a/tests/tools/test_swiftlint.py
+++ b/tests/tools/test_swiftlint.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from lintreview.review import Problems, Comment
 from lintreview.tools.swiftlint import Swiftlint
 from tests import root_dir, requires_image
-from nose.tools import eq_
 
 
 FILE_WITH_NO_ERRORS = 'tests/fixtures/swiftlint/no_errors.swift',
@@ -32,15 +31,15 @@ class TestSwiftlint(TestCase):
     @requires_image('swiftlint')
     def test_process_files_pass(self):
         self.tool.process_files(FILE_WITH_NO_ERRORS)
-        eq_([], self.problems.all(FILE_WITH_NO_ERRORS))
+        self.assertEqual([], self.problems.all(FILE_WITH_NO_ERRORS))
 
     @requires_image('swiftlint')
     def test_process_files_fail(self):
         self.tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all(FILE_WITH_ERRORS)
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
 
         msg = ("Colons should be next to the identifier when specifying "
                "a type and next to the key in dictionary literals.")
         expected = [Comment(FILE_WITH_ERRORS, 2, 2, msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
+from unittest import TestCase
+from mock import Mock
+
 import lintreview.tools as tools
-import github3
 from lintreview.config import ReviewConfig, build_review_config
 from lintreview.review import Review, Problems
-from nose.tools import eq_, raises
-from mock import Mock
+from lintreview.tools import pep8, jshint
 from tests import root_dir, fixtures_path, requires_image
+
+import github3
 
 
 sample_ini = """
@@ -29,165 +32,162 @@ linters = not there, bogus
 """
 
 
-@raises(ImportError)
-def test_factory_raises_error_on_bad_linter():
-    gh = Mock(spec=github3.GitHub)
-    config = build_review_config(bad_ini)
-    config = ReviewConfig()
-    config.load_ini(bad_ini)
-    tools.factory(config, Review(gh, None, config), '')
+class TestTools(TestCase):
+    """Test the tools."""
 
+    def test_factory_raises_error_on_bad_linter(self):
+        gh = Mock(spec=github3.GitHub)
+        config = ReviewConfig()
+        config.load_ini(bad_ini)
+        self.assertRaises(ImportError, tools.factory, config,
+                          Review(gh, None, config), '')
 
-def test_factory_generates_tools():
-    gh = Mock(spec=github3.GitHub)
-    config = build_review_config(sample_ini)
-    linters = tools.factory(config, Review(gh, None, config), '')
-    eq_(2, len(linters))
-    assert isinstance(linters[0], tools.pep8.Pep8)
-    assert isinstance(linters[1], tools.jshint.Jshint)
+    def test_tool_repr(self):
+        gh = Mock(spec=github3.GitHub)
+        config = build_review_config(sample_ini)
+        linters = tools.factory(config, Review(gh, None, config), '')
+        self.assertIn('<pep8Tool config:', str(linters[0]))
 
+    def test_factory_generates_tools(self):
+        gh = Mock(spec=github3.GitHub)
+        config = build_review_config(sample_ini)
+        linters = tools.factory(config, Review(gh, None, config), '')
+        self.assertEqual(2, len(linters))
+        self.assertIsInstance(linters[0], pep8.Pep8)
+        self.assertIsInstance(linters[1], jshint.Jshint)
 
-def test_tool_constructor__config():
-    problems = Problems()
-    config = {'good': 'value'}
-    tool = tools.Tool(problems, config)
-    eq_(tool.options, config)
+    def test_tool_constructor__config(self):
+        problems = Problems()
+        config = {'good': 'value'}
+        tool = tools.Tool(problems, config)
+        self.assertEqual(tool.options, config)
 
-    tool = tools.Tool(problems, 'derp')
-    eq_(tool.options, {})
+        tool = tools.Tool(problems, 'derp')
+        self.assertEqual(tool.options, {})
 
-    tool = tools.Tool(problems, 2)
-    eq_(tool.options, {})
+        tool = tools.Tool(problems, 2)
+        self.assertEqual(tool.options, {})
 
-    tool = tools.Tool(problems, None)
-    eq_(tool.options, {})
+        tool = tools.Tool(problems, None)
+        self.assertEqual(tool.options, {})
 
+    def test_tool_apply_base__no_base(self):
+        problems = Problems()
+        tool = tools.Tool(problems, {})
 
-def test_tool_apply_base__no_base():
-    problems = Problems()
-    tool = tools.Tool(problems, {})
+        result = tool.apply_base('comments_current.json')
+        self.assertEqual(result, 'comments_current.json')
 
-    result = tool.apply_base('comments_current.json')
-    eq_(result, 'comments_current.json')
+    def test_tool_apply_base__with_base(self):
+        problems = Problems()
+        tool = tools.Tool(problems, {}, fixtures_path)
 
+        result = tool.apply_base('comments_current.json')
+        self.assertEqual(result, fixtures_path + '/comments_current.json')
 
-def test_tool_apply_base__with_base():
-    problems = Problems()
-    tool = tools.Tool(problems, {}, fixtures_path)
+        result = tool.apply_base('./comments_current.json')
+        self.assertEqual(result, fixtures_path + '/comments_current.json')
 
-    result = tool.apply_base('comments_current.json')
-    eq_(result, fixtures_path + '/comments_current.json')
+        result = tool.apply_base('eslint/config.json')
+        self.assertEqual(result, fixtures_path + '/eslint/config.json')
 
-    result = tool.apply_base('./comments_current.json')
-    eq_(result, fixtures_path + '/comments_current.json')
+        result = tool.apply_base('./eslint/config.json')
+        self.assertEqual(result, fixtures_path + '/eslint/config.json')
 
-    result = tool.apply_base('eslint/config.json')
-    eq_(result, fixtures_path + '/eslint/config.json')
+        result = tool.apply_base('../fixtures/eslint/config.json')
+        self.assertEqual(result, fixtures_path + '/eslint/config.json')
 
-    result = tool.apply_base('./eslint/config.json')
-    eq_(result, fixtures_path + '/eslint/config.json')
+    def test_tool_apply_base__with_base_no_traversal(self):
+        problems = Problems()
+        tool = tools.Tool(problems, {}, fixtures_path)
 
-    result = tool.apply_base('../fixtures/eslint/config.json')
-    eq_(result, fixtures_path + '/eslint/config.json')
+        result = tool.apply_base('../../../comments_current.json')
+        self.assertEqual(result, 'comments_current.json')
 
+    @requires_image('python2')
+    def test_run(self):
+        config = build_review_config(simple_ini)
+        problems = Problems()
+        files = ['./tests/fixtures/pep8/has_errors.py']
+        tool_list = tools.factory(config, problems, root_dir)
+        tools.run(tool_list, files, [])
+        self.assertEqual(7, len(problems))
 
-def test_tool_apply_base__with_base_no_traversal():
-    problems = Problems()
-    tool = tools.Tool(problems, {}, fixtures_path)
+    @requires_image('python2')
+    def test_run__filter_files(self):
+        config = build_review_config(simple_ini)
+        problems = Problems()
+        files = [
+            './tests/fixtures/pep8/has_errors.py',
+            './tests/fixtures/phpcs/has_errors.php'
+        ]
+        tool_list = tools.factory(config, problems, root_dir)
+        tools.run(tool_list, files, [])
+        self.assertEqual(7, len(problems))
 
-    result = tool.apply_base('../../../comments_current.json')
-    eq_(result, 'comments_current.json')
+    def test_python_image(self):
+        self.assertEqual('python2', tools.python_image(False))
+        self.assertEqual('python2', tools.python_image(''))
+        self.assertEqual('python2', tools.python_image('derp'))
+        self.assertEqual('python2', tools.python_image({}))
+        self.assertEqual('python2', tools.python_image([]))
+        self.assertEqual('python2', tools.python_image({'python': 2}))
+        self.assertEqual('python2', tools.python_image({'python': '2'}))
+        self.assertEqual('python3', tools.python_image({'python': '3'}))
+        self.assertEqual('python3', tools.python_image({'python': 3}))
 
+    def test_process_checkstyle(self):
+        problems = Problems()
+        xml = """
+    <checkstyle>
+      <file name="things.py">
+        <error line="1" message="Not good" />
+        <error line="2" message="Also not good" />
+      </file>
+      <file name="other_things.py">
+        <error line="3" message="Not good" />
+      </file>
+    </checkstyle>
+    """
+        tools.process_checkstyle(problems, xml, lambda x: x)
+        self.assertEqual(3, len(problems))
 
-@requires_image('python2')
-def test_run():
-    config = build_review_config(simple_ini)
-    problems = Problems()
-    files = ['./tests/fixtures/pep8/has_errors.py']
-    tool_list = tools.factory(config, problems, root_dir)
-    tools.run(tool_list, files, [])
-    eq_(7, len(problems))
+        things = problems.all('things.py')
+        self.assertEqual(2, len(things))
+        self.assertEqual(1, things[0].line)
+        self.assertEqual('Not good', things[0].body)
 
+    def test_process_checkstyle__comma_lines(self):
+        problems = Problems()
+        xml = """
+    <checkstyle>
+      <file name="other_things.py">
+        <error line="3,4,5" message="Not good" />
+      </file>
+    </checkstyle>
+    """
+        tools.process_checkstyle(problems, xml, lambda x: x)
+        self.assertEqual(3, len(problems))
 
-@requires_image('python2')
-def test_run__filter_files():
-    config = build_review_config(simple_ini)
-    problems = Problems()
-    files = [
-        './tests/fixtures/pep8/has_errors.py',
-        './tests/fixtures/phpcs/has_errors.php'
-    ]
-    tool_list = tools.factory(config, problems, root_dir)
-    tools.run(tool_list, files, [])
-    eq_(7, len(problems))
+        things = problems.all('other_things.py')
+        self.assertEqual(3, len(things))
+        self.assertEqual(3, things[0].line)
+        self.assertEqual('Not good', things[0].body)
 
+        self.assertEqual(4, things[1].line)
+        self.assertEqual('Not good', things[1].body)
 
-def test_python_image():
-    eq_('python2', tools.python_image(False))
-    eq_('python2', tools.python_image(''))
-    eq_('python2', tools.python_image('derp'))
-    eq_('python2', tools.python_image({}))
-    eq_('python2', tools.python_image([]))
-    eq_('python2', tools.python_image({'python': 2}))
-    eq_('python2', tools.python_image({'python': '2'}))
-    eq_('python3', tools.python_image({'python': '3'}))
-    eq_('python3', tools.python_image({'python': 3}))
+        self.assertEqual(5, things[2].line)
+        self.assertEqual('Not good', things[2].body)
 
-
-def test_process_checkstyle():
-    problems = Problems()
-    xml = """
-<checkstyle>
-  <file name="things.py">
-    <error line="1" message="Not good" />
-    <error line="2" message="Also not good" />
-  </file>
-  <file name="other_things.py">
-    <error line="3" message="Not good" />
-  </file>
-</checkstyle>
-"""
-    tools.process_checkstyle(problems, xml, lambda x: x)
-    eq_(3, len(problems))
-
-    things = problems.all('things.py')
-    eq_(2, len(things))
-    eq_(1, things[0].line)
-    eq_('Not good', things[0].body)
-
-
-def test_process_checkstyle__comma_lines():
-    problems = Problems()
-    xml = """
-<checkstyle>
-  <file name="other_things.py">
-    <error line="3,4,5" message="Not good" />
-  </file>
-</checkstyle>
-"""
-    tools.process_checkstyle(problems, xml, lambda x: x)
-    eq_(3, len(problems))
-
-    things = problems.all('other_things.py')
-    eq_(3, len(things))
-    eq_(3, things[0].line)
-    eq_('Not good', things[0].body)
-
-    eq_(4, things[1].line)
-    eq_('Not good', things[1].body)
-
-    eq_(5, things[2].line)
-    eq_('Not good', things[2].body)
-
-
-def test_process_checkstyle__non_int():
-    problems = Problems()
-    xml = """
-<checkstyle>
-  <file name="other_things.py">
-    <error line="undefined" message="Not good" />
-  </file>
-</checkstyle>
-"""
-    tools.process_checkstyle(problems, xml, lambda x: x)
-    eq_(0, len(problems))
+    def test_process_checkstyle__non_int(self):
+        problems = Problems()
+        xml = """
+    <checkstyle>
+      <file name="other_things.py">
+        <error line="undefined" message="Not good" />
+      </file>
+    </checkstyle>
+    """
+        tools.process_checkstyle(problems, xml, lambda x: x)
+        self.assertEqual(0, len(problems))

--- a/tests/tools/test_tslint.py
+++ b/tests/tools/test_tslint.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 from unittest import TestCase
+
 from lintreview.review import Comment, IssueComment, Problems
 from lintreview.tools.tslint import Tslint
-from nose.tools import eq_, ok_
-from tests import root_dir, requires_image
+from tests import requires_image, root_dir
 
 FILE_WITH_NO_ERRORS = 'tests/fixtures/tslint/no_errors.ts',
 FILE_WITH_ERRORS = 'tests/fixtures/tslint/has_errors.ts'
@@ -33,18 +33,18 @@ class TestTslint(TestCase):
     @requires_image('nodejs')
     def test_process_files__pass(self):
         self.tool.process_files(FILE_WITH_NO_ERRORS)
-        eq_([], self.problems.all(FILE_WITH_NO_ERRORS))
+        self.assertEqual([], self.problems.all(FILE_WITH_NO_ERRORS))
 
     @requires_image('nodejs')
     def test_process_files__fail(self):
         self.tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all(FILE_WITH_ERRORS)
-        eq_(3, len(problems))
+        self.assertEqual(3, len(problems))
 
         msg = ("Shadowed name: 'range'\n"
                "Spaces before function parens are disallowed")
         expected = Comment(FILE_WITH_ERRORS, 1, 1, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
     @requires_image('nodejs')
     def test_process_files__invalid_config(self):
@@ -53,22 +53,22 @@ class TestTslint(TestCase):
                       base_path=root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config returns 1 error')
+        self.assertEqual(1, len(problems), 'Invalid config returns 1 error')
         msg = ('Your tslint configuration file is missing or invalid. '
                'Please ensure that `invalid-file` exists and is valid JSON.')
         expected = [IssueComment(msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)
 
     @requires_image('nodejs')
     def test_process_files__no_config_set_no_default(self):
         tool = Tslint(self.problems, options={}, base_path=root_dir)
         tool.process_files([FILE_WITH_ERRORS])
         problems = self.problems.all()
-        eq_(1, len(problems), 'Missing config returns 1 error')
+        self.assertEqual(1, len(problems), 'Missing config returns 1 error')
         msg = ('Your tslint configuration file is missing or invalid. '
                'Please ensure that `tslint.json` exists and is valid JSON.')
         expected = [IssueComment(msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)
 
     @requires_image('nodejs')
     def test_process_files_with_config(self):
@@ -83,11 +83,11 @@ class TestTslint(TestCase):
         msg = ("Shadowed name: 'range'\n"
                'Spaces before function parens are disallowed')
         expected = Comment(FILE_WITH_ERRORS, 1, 1, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         msg = "The key 'middle' is not sorted alphabetically"
         expected = Comment(FILE_WITH_ERRORS, 11, 11, msg)
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('nodejs')
     def test_process_files__invalid_rule(self):
@@ -98,7 +98,7 @@ class TestTslint(TestCase):
         tool.process_files([FILE_WITH_ERRORS])
 
         problems = self.problems.all()
-        eq_(1, len(problems))
+        self.assertEqual(1, len(problems))
         msg = ('Your tslint configuration output the following error:\n'
                '```\n'
                'Could not find implementations for the following rules '
@@ -110,7 +110,7 @@ class TestTslint(TestCase):
                'have old rules configured which need to be cleaned up.\n'
                '```')
         expected = [IssueComment(msg)]
-        eq_(expected, problems)
+        self.assertEqual(expected, problems)
 
     @requires_image('nodejs')
     def test_process_files__warnings(self):
@@ -121,15 +121,15 @@ class TestTslint(TestCase):
         tool.process_files([FILE_WITH_ERRORS])
 
         problems = self.problems.all()
-        eq_(4, len(problems))
+        self.assertEqual(4, len(problems))
         expected = (
             '`tslint` output the following warnings:\n'
             '\n'
             "* The 'no-boolean-literal-compare' rule requires type "
             "information."
         )
-        eq_(expected, problems[0].body)
-        ok_("Shadowed name: 'range'" in problems[1].body)
+        self.assertEqual(expected, problems[0].body)
+        self.assertIn("Shadowed name: 'range'", problems[1].body)
 
     @requires_image('nodejs')
     def test_process_files__unknown_module(self):
@@ -140,10 +140,11 @@ class TestTslint(TestCase):
         tool.process_files([FILE_WITH_ERRORS])
 
         problems = self.problems.all()
-        eq_(1, len(problems), 'Invalid config should report an error')
+        self.assertEqual(1, len(problems),
+                         'Invalid config should report an error')
 
         error = problems[0]
-        ok_('Your tslint configuration output the following error:'
-            in error.body)
-        ok_('Invalid "extends" configuration value' in error.body)
-        ok_('could not require "tslint-lol"' in error.body)
+        self.assertIn('Your tslint configuration output the following error:',
+                      error.body)
+        self.assertIn('Invalid "extends" configuration value', error.body)
+        self.assertIn('could not require "tslint-lol"', error.body)

--- a/tests/tools/test_yamllint.py
+++ b/tests/tools/test_yamllint.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
+from unittest import TestCase
+
 from lintreview.review import Problems, Comment
 from lintreview.tools.yamllint import Yamllint
-from unittest import TestCase
-from nose.tools import eq_, assert_in
 from tests import root_dir, requires_image
 
 
@@ -29,44 +29,44 @@ class TestYamllint(TestCase):
     @requires_image('python2')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
     @requires_image('python2')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        eq_(5, len(problems))
+        self.assertEqual(5, len(problems))
 
         fname = self.fixtures[1]
 
         msg = "[warning] missing starting space in comment (comments)"
         expected = Comment(fname, 1, 1, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         msg = ("[warning] missing document start \"---\" (document-start)\n"
                "[error] too many spaces inside braces (braces)")
         expected = Comment(fname, 2, 2, msg)
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('python2')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
-        eq_([], self.problems.all(self.fixtures[0]))
+        self.assertEqual([], self.problems.all(self.fixtures[0]))
 
         problems = self.problems.all(self.fixtures[1])
-        eq_(5, len(problems))
+        self.assertEqual(5, len(problems))
 
         fname = self.fixtures[1]
 
         msg = "[warning] missing starting space in comment (comments)"
         expected = Comment(fname, 1, 1, msg)
-        eq_(expected, problems[0])
+        self.assertEqual(expected, problems[0])
 
         msg = ("[warning] missing document start \"---\" (document-start)\n"
                "[error] too many spaces inside braces (braces)")
         expected = Comment(fname, 2, 2, msg)
-        eq_(expected, problems[1])
+        self.assertEqual(expected, problems[1])
 
     @requires_image('python2')
     def test_process_files__config(self):
@@ -78,8 +78,8 @@ class TestYamllint(TestCase):
 
         problems = self.problems.all(self.fixtures[0])
 
-        eq_(1, len(problems),
-            'Config file should cause errors on no_errors.yml')
+        self.assertEqual(1, len(problems),
+                         'Config file should cause errors on no_errors.yml')
 
     @requires_image('python2')
     def test_process_files__missing_config(self):
@@ -91,8 +91,8 @@ class TestYamllint(TestCase):
 
         problems = self.problems.all()
 
-        eq_(1, len(problems))
-        assert_in(
+        self.assertEqual(1, len(problems))
+        self.assertIn(
             '`yamllint` failed with the following error:\n'
             '```\n'
             "IOError: [Errno 2] No such file or directory: "


### PR DESCRIPTION
Nosetest has been in "maintenance mode" for a number of years now and no
updates are expected.

Most changes utilize python's unittest instead of pytest directives to
improve later portability.

## Goals

*  Use `unittest` as much as possible, to allow future refactorings
*  Use `pytest` instead of nosetests to:
   *   Facilitate an easier python3 transition
   *   Use a current and updated framework
   *   Allow easy onboarding of new contributors with a widely used testing framework
*  No changes to source outside of `tests`
*  Coverage parity (helps ensure we don't miss any tests/asserts)
*  Workflow parity
   *   can run the tests that don't require the linter locally (docker-compose with `docker-compose.test.yaml` still runs a subset of the tests)
   *   can run *all* the tests (ensure all dockers are built/pulled locally)

## notes

1.  We now pull the swiftlint docker in travis, to test that fully

## todo

- [x] Revert back to using `requires_image` to maintain workflows.
- [x] Swap out `pytest.raises` to `self.assertRaises` for future portability
- [x] Consider if a `skipIf` would be better than `pytest.mark.requires_linters` to further remove the test framework dependency from the tests
- [x] evaluate coverage decreases on files reported by codecov