### PR TITLE
Use the docker API instead of shelling out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
-FROM ubuntu:16.04
-ENV REFRESHED_AT 2018-02-24
+FROM python:2.7.16-slim-stretch
+ENV REFRESHED_AT 2019-03-31
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-RUN apt-get update && \
-    apt-get install -y \
-    python2.7 python-pip \
-    curl \
-    git \
-    libxml2 \
-    libffi-dev \
-    zlib1g-dev \
-    docker.io \
-    language-pack-en \
-    build-essential && \
-    dpkg-reconfigure locales && \
-    apt-get -y autoremove && \
-    apt-get -y clean  && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git
 
 WORKDIR /code
-
 # This allows us to cache the pip install stage
 ADD requirements.txt /
 RUN pip install -r /requirements.txt

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,3 +2,5 @@
 sut:
   build: .
   command: /code/docker_tests.sh
+  volumes:
+    - '/var/run/docker.sock:/var/run/docker.sock'

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -18,6 +18,10 @@ log = logging.getLogger(__name__)
 DOCKER_BASE = '/src'
 
 
+class TimeoutError(Exception):
+    """Exception for when we timeout waiting for docker."""
+
+
 def _get_client():
     # type: () -> docker.DockerClient
     """Get a docker client."""
@@ -149,7 +153,7 @@ def run(image,              # type: str
         output += container.logs(stdout=True, stderr=False)
     except (APIError, ReadTimeout, ConnectionError):
         log.exception("Container.wait exception.")
-        return "Exception waiting for container to finish."
+        raise TimeoutError()
     finally:
         if name is None:
             container.remove(v=True, force=True)

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -72,9 +72,8 @@ def images():
     # type: () -> List[str]
     """Get the docker image list."""
     client = _get_client()
-    d_images = client.images.list()
     results = []
-    for image in d_images:
+    for image in client.images.list():
         results += image.tags
     return results
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ gunicorn==19.5.0
 argparse>=1.2.0,<=1.3.0
 jprops==2.0.2
 six>=1.11.0,<1.12.0
+docker==3.7.1
+requests==2.21.0
+typing==3.6.6

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -49,4 +49,34 @@ class TestDocker(TestCase):
     @requires_image('python2')
     def test_images(self):
         result = docker.images()
-        self.assertIn('python2', result)
+        self.assertIn('python2:latest', result)
+
+    def test_image_exists__no_exist(self):
+        self.assertFalse(docker.image_exists('nevergonnaexist:tacos'))
+
+    def test_rm_container__no_exist(self):
+        self.assertRaises(ValueError,
+                          docker.rm_container,
+                          'anamethatdoesnotexist')
+
+    def test_rm_image__no_exist(self):
+        self.assertRaises(ValueError,
+                          docker.rm_image,
+                          'anamethatdoesnotexist')
+
+    def test_commit__no_exist(self):
+        self.assertRaises(ValueError,
+                          docker.commit,
+                          'anamethatdoesnotexist')
+
+    def test_run__no_exist(self):
+        expected = 'Image not found.'
+        actual = docker.run('anamethatdoesnotexist', [], test_dir)
+        self.assertEqual(expected, actual)
+
+    @requires_image('python2')
+    def test_run__timeout(self):
+        expected = 'Exception waiting for container to finish.'
+        cmd = ['python', '-c', 'import time; time.sleep(10)']
+        actual = docker.run('python2', cmd, test_dir, timeout=5)
+        self.assertEqual(expected, actual)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -76,7 +76,9 @@ class TestDocker(TestCase):
 
     @requires_image('python2')
     def test_run__timeout(self):
-        expected = 'Exception waiting for container to finish.'
         cmd = ['python', '-c', 'import time; time.sleep(10)']
-        actual = docker.run('python2', cmd, test_dir, timeout=5)
-        self.assertEqual(expected, actual)
+        self.assertRaises(
+            docker.TimeoutError,
+            docker.run,
+            'python2', cmd, test_dir, timeout=5
+        )

--- a/tests/tools/test_eslint.py
+++ b/tests/tools/test_eslint.py
@@ -213,7 +213,9 @@ class TestEslint(TestCase):
 
         self.assertTrue(docker.image_exists('nodejs'),
                         'original image is present')
-        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')
+
+        for image in docker.images():
+            self.assertNotIn('eslint-', image, 'no eslint image remains')
 
     @requires_image('eslint')
     def test_execute_fixer__install_plugins(self):
@@ -234,7 +236,8 @@ class TestEslint(TestCase):
         read_and_restore_file(target, original)
         self.assertEqual(0, len(self.problems.all()),
                          'All errors should be autofixed')
-        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')
+        for image in docker.images():
+            self.assertNotIn('eslint-', image, 'no eslint image remains')
 
     @requires_image('eslint')
     def test_execute__install_plugins_cleanup_image_on_failure(self):
@@ -253,4 +256,5 @@ class TestEslint(TestCase):
 
         self.assertTrue(docker.image_exists('eslint'),
                         'original image is present')
-        self.assertNotIn('eslint-', docker.images(), 'no eslint image remains')
+        for image in docker.images():
+            self.assertNotIn('eslint-', image, 'no eslint image remains')


### PR DESCRIPTION
Using subprocess can be slow in python, and the code is a bit cleaner if we use the python-docker library (which uses requests against the docker socket).

## Modifications to the tests 
I did have to modify one thing in the tests, and that was calls to `docker.images()` which is never called by the main app. 

1.   The `eslint` tests were never valid because looking for a substring match in a list with the `in` operator doesn't work, you'll only find exact string matches in the list.
2.   The docker test that was changed is technically a backwards incompatible change, as the call now returns the tags with the image names (`python2:latest`). Since we don't ever call `docker.images` this seems like it's fine, but I can mimic the old behavior by splitting the images on `:` and returning only the image name if that's the desired functionality, let me know.

## What's in this PR

1.   Move to the python-docker library instead of subprocess
2.  Use type annotations (python2 style) to
     *   clarify usage
     *   improve safety developing against this core library (better chance you won't use the wrong arg type)
3.   Switch to the official python base docker instead of ubuntu, upgrading us to 2.7.16 (latest 2x series)

## Notes

1.   This keeps the current functionality of smashing together the docker run logs and the docker error logs, but there should be future consideration around possibly returning them separately for easier parsing.
2.   I backported this from python3 to python2 (my branch is all python3) so I *think* I got all the nasty py2 `str` surprises worked out, but a careful look at the inputs/outputs is warranted.
3.   The docker library has the ability to return logs synchronously, but we couldn't use that for the following reasons
      *   If a docker run returns a non-zero exit code, an exception is raised and the logs are lost, so failing to lint would cause us to not get logs back (can go into more detail if you like
      *   This allows us to implement the `timeout` kwarg that was present in the function signature, but never used
4.   Because we no longer subprocess out, the docker api client expects that the docker socket is present, which means we must mount the docker socket into the docker-compose.tests.yaml. The tests will fail if you use docker compose and don't have a socket. We could potentially error-check for a missing socket...but it seems silly given that you *never* want to have the app running without access to docker, so mounting it in the docker-compose tests seems like a good compromise.

## Future Improvements

1.   There seems to be almost 0 penalty for creating the docker client, I'm not sure it does anything other than an object allocation (possibly just creating a requests session) and it's not until you use it that it does anything, but maybe we should cache the client at some point.

## Tasks

- [ ] Get approval for API functionality change on `docker.images()`
- [x] Tests pass
- [x] Coverage Parity