### PR TITLE
docker_healthcheck.sh requires curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV REFRESHED_AT 2019-03-31
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git curl
 
 WORKDIR /code
 # This allows us to cache the pip install stage


### PR DESCRIPTION
Sorry! I realized today when I pushed out some changes that the healthcheck in the web container uses curl, I thought it was just for pulling down docker!