### PR TITLE
Re-implement path ignores for py3k

### DIFF
--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -82,11 +82,12 @@ class Py3k(Tool):
             else:
                 matchers.append(matcher)
 
-        has_match = lambda name: any([
-            True
-            for matcher in matchers
-            if matcher.search(name)
-        ])
+        def has_match(name):
+            return any([
+                True
+                for matcher in matchers
+                if matcher.search(name)
+            ])
 
         keepers = []
         for name in files:

--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -63,7 +63,6 @@ class Py3k(Tool):
         # paths, so we have to do that ourselves.
         if 'ignore-patterns' in self.options:
             files = self.apply_ignores(self.options['ignore-patterns'], files)
-            print files
 
         for option in self.options:
             if option in accepted_options:

--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import os
 import logging
 import lintreview.docker as docker
+import re
 from lintreview.tools import Tool, process_quickfix, stringify
 
 log = logging.getLogger(__name__)
@@ -57,11 +58,12 @@ class Py3k(Tool):
         accepted_options = ('ignore')
         if 'ignore' in self.options:
             command.extend(['-d', stringify(self.options['ignore'])])
+
+        # Pylint's ignore-patterns option is unable to ignore
+        # paths, so we have to do that ourselves.
         if 'ignore-patterns' in self.options:
-            command.extend([
-                '--ignore-patterns',
-                stringify(self.options['ignore-patterns'])
-            ])
+            files = self.apply_ignores(self.options['ignore-patterns'], files)
+            print files
 
         for option in self.options:
             if option in accepted_options:
@@ -69,3 +71,25 @@ class Py3k(Tool):
             log.warning('Set non-existent py3k option: %s', option)
         command.extend(files)
         return command
+
+    def apply_ignores(self, patterns, files):
+        matchers = []
+        for pattern in stringify(patterns).split(','):
+            try:
+                matcher = re.compile(pattern)
+            except Exception:
+                continue
+            else:
+                matchers.append(matcher)
+
+        has_match = lambda name: any([
+            True
+            for matcher in matchers
+            if matcher.search(name)
+        ])
+
+        keepers = []
+        for name in files:
+            if not has_match(name):
+                keepers.append(name)
+        return keepers

--- a/tests/tools/test_py3k.py
+++ b/tests/tools/test_py3k.py
@@ -77,7 +77,25 @@ class TestPy3k(TestCase):
     @requires_image('python2')
     def test_process_files__ignore_patterns(self):
         tool = Py3k(self.problems,
-                    {'ignore-patterns': ['has_err*']},
+                    {'ignore-patterns': ['has_err.*', 'no.*']},
+                    root_dir)
+        tool.process_files([self.fixtures.has_errors])
+        problems = self.problems.all(self.fixtures.has_errors)
+        self.assertEqual(0, len(problems))
+
+    @requires_image('python2')
+    def test_process_files__ignore_pattern_string(self):
+        tool = Py3k(self.problems,
+                    {'ignore-patterns': 'has.*,no_.*'},
+                    root_dir)
+        tool.process_files([self.fixtures.has_errors])
+        problems = self.problems.all(self.fixtures.has_errors)
+        self.assertEqual(0, len(problems))
+
+    @requires_image('python2')
+    def test_process_files__ignore_pattern_path(self):
+        tool = Py3k(self.problems,
+                    {'ignore-patterns': 'fixtures/py3k/.*'},
                     root_dir)
         tool.process_files([self.fixtures.has_errors])
         problems = self.problems.all(self.fixtures.has_errors)

--- a/tests/tools/test_py3k.py
+++ b/tests/tools/test_py3k.py
@@ -100,3 +100,21 @@ class TestPy3k(TestCase):
         tool.process_files([self.fixtures.has_errors])
         problems = self.problems.all(self.fixtures.has_errors)
         self.assertEqual(0, len(problems))
+
+    @requires_image('python2')
+    def test_process_files__ignore_pattern_miss(self):
+        tool = Py3k(self.problems,
+                    {'ignore-patterns': 'foo.*'},
+                    root_dir)
+        tool.process_files([self.fixtures.has_errors])
+        problems = self.problems.all(self.fixtures.has_errors)
+        self.assertEqual(2, len(problems))
+
+    @requires_image('python2')
+    def test_process_files__ignore_pattern_corrupt(self):
+        tool = Py3k(self.problems,
+                    {'ignore-patterns': '(foo'},
+                    root_dir)
+        tool.process_files([self.fixtures.has_errors])
+        problems = self.problems.all(self.fixtures.has_errors)
+        self.assertEqual(2, len(problems))


### PR DESCRIPTION
The pylint ignore-patterns option does not allow matching on directories. That is what people expect from an ignore-pattern so we can implement that in the tool bridge.