### PR TITLE
Handle linter timeouts more gracefully

### DIFF
--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -155,9 +155,9 @@ def run(image,                    # type: str
         if include_error:
             output += container.logs(stdout=False, stderr=True)
         output += container.logs(stdout=True, stderr=False)
-    except (APIError, ReadTimeout, ConnectionError):
-        log.exception("Container.wait exception.")
-        raise TimeoutError()
+    except (APIError, ReadTimeout, ConnectionError) as e:
+        log.error("%s container timed out error=%s.", image, e)
+        raise TimeoutError(six.text_type(e))
     finally:
         if name is None:
             container.remove(v=True, force=True)

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -48,7 +48,7 @@ class Tool(object):
         log.info('Running %s on %d files', self.name, num_files)
         try:
             self.process_files(matching_files)
-        except docker.TimeoutError as e:
+        except docker.TimeoutError:
             msg = 'Failed to run %s linter. It timed out during execution.'
             self.problems.add(IssueComment(msg % (self.name)))
 

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
-import lintreview.docker as docker
 import logging
 import os
 import collections
-from xml.etree import ElementTree
 import six
+
+import lintreview.docker as docker
+
+from lintreview.review import IssueComment
+from xml.etree import ElementTree
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +46,11 @@ class Tool(object):
             return
 
         log.info('Running %s on %d files', self.name, num_files)
-        self.process_files(matching_files)
+        try:
+            self.process_files(matching_files)
+        except docker.TimeoutError as e:
+            msg = 'Failed to run %s linter. It timed out during execution.'
+            self.problems.add(IssueComment(msg % (self.name)))
 
     def execute_commits(self, commits):
         """


### PR DESCRIPTION
Instead of failing the entire job, handle linter timeouts locally and allow other linters to continue running.