### PR TITLE
Make fixer failure not fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 python:
   - "2.7"
-  - "3.7"
+  - "3.6"
 
 env:
   - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 env:
   - LINTREVIEW_SETTINGS="./settings.py" GOPATH="${TRAVIS_BUILD_DIR}/gocode"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ---
 language: python
 
-dist: 'trusty'
-
 services:
   - docker
 

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -4,7 +4,7 @@ import lintreview.tools as tools
 import lintreview.fixers as fixers
 from lintreview.diff import DiffCollection
 from lintreview.fixers.error import ConfigurationError, WorkflowError
-from lintreview.review import Problems, Review, IssueComment, InfoComment
+from lintreview.review import Problems, Review, InfoComment
 
 log = logging.getLogger(__name__)
 

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -4,7 +4,7 @@ import lintreview.tools as tools
 import lintreview.fixers as fixers
 from lintreview.diff import DiffCollection
 from lintreview.fixers.error import ConfigurationError, WorkflowError
-from lintreview.review import Problems, Review, IssueComment
+from lintreview.review import Problems, Review, IssueComment, InfoComment
 
 log = logging.getLogger(__name__)
 
@@ -71,11 +71,11 @@ class Processor(object):
                 fixer_diff,
                 fixer_context)
         except (ConfigurationError, WorkflowError) as e:
-            log.warn('Fixer application failed. Got %s', e)
+            log.info('Fixer application failed. Got %s', e)
             message = u'Unable to apply fixers. {}'.format(e)
-            self.problems.add(IssueComment(message))
+            self.problems.add(InfoComment(message))
         except Exception as e:
-            log.warn('Fixer application failed, '
+            log.info('Fixer application failed, '
                      'rolling back working tree. Got %s', e)
             fixers.rollback_changes(self._target_path)
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -159,10 +159,10 @@ class TestProcessor(TestCase):
         self.fixer_stub.run_fixers.assert_called()
         self.tool_stub.run.assert_called()
         self.fixer_stub.rollback_changes.assert_not_called()
-        self.assertEqual(1, len(subject.problems),
-                         'strategy error adds pull comment')
-        self.assertEqual('Unable to apply fixers. ' + str(error),
-                         subject.problems.all()[0].body)
+        assert 1 == len(subject.problems), 'strategy error adds pull comment'
+        assert 0 == subject.problems.error_count(), 'fixer failure should be info level'
+        assert 'Unable to apply fixers. ' + str(error) == subject.problems.all()[0].body
+        assert 1 == len(subject.problems), 'strategy error adds pull comment'
 
     def test_publish(self):
         pull = self.get_pull_request()

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -6,7 +6,7 @@ from mock import Mock, patch
 from . import load_fixture, fixer_ini
 from lintreview.config import load_config, build_review_config
 from lintreview.diff import DiffCollection
-from lintreview.review import Review, Problems, Comment, IssueComment
+from lintreview.review import Review, Problems, Comment, IssueComment, InfoComment
 from lintreview.repo import GithubRepository, GithubPullRequest
 from github3.issues.comment import IssueComment as GhIssueComment
 from github3.pulls import PullFile
@@ -551,6 +551,24 @@ class TestProblems(TestCase):
         result = self.problems.all('some/file.py')
         self.assertEqual(2, len(result))
         self.assertEqual(errors, result)
+
+    def test_error_count(self):
+        errors = [
+            Comment('some/file.py', 10, 10, 'Thing is wrong'),
+            Comment('some/file.py', 12, 12, 'Not good'),
+        ]
+        self.problems.add_many(errors)
+        assert 2 == len(self.problems)
+        assert 2 == self.problems.error_count()
+
+    def test_error_count_exclude_info(self):
+        errors = [
+            Comment('some/file.py', 10, 10, 'Thing is wrong'),
+            InfoComment('some content'),
+        ]
+        self.problems.add_many(errors)
+        assert 1 == self.problems.error_count()
+        assert 2 == len(self.problems)
 
     def test_limit_to_changes__remove_problems(self):
         res = [


### PR DESCRIPTION
There exist scenarios where the original diff passes review, but a fixer will expand the chunk, and fail to be pushed due to forks. This should not cause a build result to be a failure.