### PR TITLE
Chunk annotations to avoid rate limits

### DIFF
--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -226,6 +226,8 @@ class Review(object):
         # Update the checkrun with additional annotations.
         return {
             'output': {
+                'title': title,
+                'summary': "\n".join(summary),
                 'annotations': comments
             }
         }

--- a/lintreview/review.py
+++ b/lintreview/review.py
@@ -57,6 +57,7 @@ class IssueComment(BaseComment):
     """A simple comment that will be published as a
     pull request/issue comment.
     """
+
     def __init__(self, body=''):
         self.body = body
 
@@ -404,6 +405,7 @@ class Problems(object):
     Used by tool objects to collect problems, and by
     the Review objects to publish results.
     """
+
     def __init__(self, changes=None):
         self._items = OrderedDict()
         self._changes = changes
@@ -502,7 +504,7 @@ class Problems(object):
         """Split the problems into chunks
         Useful when publishing as a checkrun result.
         """
-        values = self._items.values()
+        values = list(self._items.values())
         for i in range(0, len(values), size):
             yield values[i:i+size]
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -469,9 +469,10 @@ class TestReview(TestCase):
         # The second payload should only contain additional annotations.
         second_payload = second_call[0][1]
         assert 'completed_at' not in second_payload
-        assert 'title' not in second_payload['output']
-        assert 'summary' not in second_payload['output']
+        assert 'title' in second_payload['output']
+        assert 'summary' in second_payload['output']
         assert 'annotations' in second_payload['output']
+        assert 'In the body' == second_payload['output']['summary']
 
         assert 20 == len(second_payload['output']['annotations'])
 

--- a/tests/tools/test_credo.py
+++ b/tests/tools/test_credo.py
@@ -47,6 +47,6 @@ class TestCredo(TestCase):
         problems = self.problems.all(self.fixtures[1])
         self.assertEqual(1, len(problems))
         fname = self.fixtures[1]
-        expected = Comment(fname, 3, 3,
-                           'Pipe chain should start with a raw value.')
+        expected = Comment(fname, 1, 1,
+                           'Modules should have a @moduledoc tag.')
         self.assertEqual(expected, problems[0])

--- a/tests/tools/test_credo.py
+++ b/tests/tools/test_credo.py
@@ -45,11 +45,8 @@ class TestCredo(TestCase):
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
-        self.assertEqual(2, len(problems))
+        self.assertEqual(1, len(problems))
         fname = self.fixtures[1]
         expected = Comment(fname, 3, 3,
                            'Pipe chain should start with a raw value.')
         self.assertEqual(expected, problems[0])
-        expected = Comment(fname, 1, 1,
-                           'Modules should have a @moduledoc tag.')
-        self.assertEqual(expected, problems[1])


### PR DESCRIPTION
GitHub will rate-limit large reviews to only 50 annotations per request. Send multiple PATCH requests if a review contains more than 50 comments. This should solve many of the rate limit related rejections when using checks.