### PR TITLE
Update eslint-plugin-ember to 6.6

### DIFF
--- a/docker/eslint-package.json
+++ b/docker/eslint-package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "babel-eslint": "^9.0.0",
     "eslint": "5.x",
-    "eslint-plugin-ember": "^5.2",
+    "eslint-plugin-ember": "^6.6",
     "eslint-plugin-ember-best-practices": "^1.1",
     "eslint-plugin-html": "4.x",
     "install-peerdeps": "1.x"


### PR DESCRIPTION
This should fix the following error:

`
(node:1) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "../tool/node_modules/eslint-plugin-ember/lib/config/base.js")
`

Fixed in https://github.com/ember-cli/eslint-plugin-ember/pull/267 and released in eslint-plugin-ember 6.0.0.

