### PR TITLE
Restore old head on fixer failure.

### DIFF
--- a/docker/eslint-install.sh
+++ b/docker/eslint-install.sh
@@ -13,6 +13,9 @@ do
 	# Clean up the JSON into something we can put into npm install.
 	package_name=$(echo "$package" | sed -e 's/,//' | sed -e 's/"//g' | sed -e 's/://' | awk '{print $1}')
 
+	# Output installed packages for logging
+	echo "add: $package_name"
+
 	# Install required plugins into /tool/node_modules
 	# Don't install all peerDeps as that can swap
 	# eslint to a higher version that isn't tested.

--- a/docker/eslint-install.sh
+++ b/docker/eslint-install.sh
@@ -14,9 +14,7 @@ do
 	package_name=$(echo "$package" | sed -e 's/,//' | sed -e 's/"//g' | sed -e 's/://' | awk '{print $1}')
 
 	# Install required plugins into /tool/node_modules
-	# Try to install with peerdeps first, falling back to standard yarn add
-	if ! install-peerdeps --yarn "$package_name"
-	then
-		yarn add "$package_name"
-	fi
+	# Don't install all peerDeps as that can swap
+	# eslint to a higher version that isn't tested.
+	yarn add "$package_name"
 done <  <(grep -i -E 'eslint-[plugin|config]-*' /src/package.json)

--- a/docker/eslint-package.json
+++ b/docker/eslint-package.json
@@ -7,8 +7,8 @@
     "eslint": "5.x",
     "eslint-plugin-ember": "^6.6",
     "eslint-plugin-ember-best-practices": "^1.1",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-html": "4.x",
-    "install-peerdeps": "1.x"
   },
   "eslintConfig": {
     "extends": "eslint:recommended"

--- a/docker/eslint-package.json
+++ b/docker/eslint-package.json
@@ -8,7 +8,7 @@
     "eslint-plugin-ember": "^6.6",
     "eslint-plugin-ember-best-practices": "^1.1",
     "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-html": "4.x",
+    "eslint-plugin-html": "4.x"
   },
   "eslintConfig": {
     "extends": "eslint:recommended"

--- a/lintreview/fixers/__init__.py
+++ b/lintreview/fixers/__init__.py
@@ -100,5 +100,6 @@ def add_strategy(name, implementation):
     workflow_strategies[name] = implementation
 
 
-def rollback_changes(path):
+def rollback_changes(path, old_head):
     git.reset_hard(path)
+    git.checkout(path, old_head)

--- a/lintreview/fixers/commit_strategy.py
+++ b/lintreview/fixers/commit_strategy.py
@@ -44,7 +44,10 @@ class CommitStrategy(object):
             message = six.text_type(err)
             log.debug(message)
             if '(permission denied)' in message:
-                raise WorkflowError('Could not push fix commit because permission was denied')
+                raise WorkflowError(
+                    'Could not push fix commit because permission was denied. '
+                    'This can happen when pull requests are submitted from forks.'
+                )
             if '[remote rejected]' in message:
-                raise WorkflowError('Could not push fix commit because it was not a fast-forward')
+                raise WorkflowError('Could not push fix commit because it was not a fast-forward.')
             raise err

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -74,10 +74,11 @@ class Processor(object):
             log.info('Fixer application failed. Got %s', e)
             message = u'Unable to apply fixers. {}'.format(e)
             self.problems.add(InfoComment(message))
+            fixers.rollback_changes(self._target_path, self._pull_request.head)
         except Exception as e:
             log.info('Fixer application failed, '
                      'rolling back working tree. Got %s', e)
-            fixers.rollback_changes(self._target_path)
+            fixers.rollback_changes(self._target_path, self._pull_request.head)
 
     def publish(self, check_run_id=None):
         self.problems.limit_to_changes()

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -82,7 +82,7 @@ class Eslint(Tool):
 
         if self.installed_plugins is False:
             log.info('Installing eslint plugins into %s', container_name)
-            docker.run(
+            output = docker.run(
                 'eslint',
                 ['eslint-install'],
                 source_dir=self.base_path,
@@ -91,6 +91,12 @@ class Eslint(Tool):
             docker.commit(container_name)
             docker.rm_container(container_name)
             self.installed_plugins = True
+            installed = [
+                line.strip('add:')
+                for line in output.splitlines()
+                if line.startswith('add:')
+            ]
+            log.info('Installed eslint plugins %s', installed)
 
     def _create_command(self):
         command = ['eslint', '--format', 'checkstyle']

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -172,7 +172,7 @@ class Eslint(Tool):
             error = missing_ruleset.group(0)
             return self.problems.add(IssueComment(msg.format(error)))
 
-        missing_plugin = re.search(r'ESLint couldn\'t find the plugin.*',
+        missing_plugin = re.search(r'ESLint couldn\'t find the (?:plugin|config).*',
                                    output)
         if missing_plugin:
             line = missing_plugin.group(0)
@@ -181,5 +181,5 @@ class Eslint(Tool):
                   '```\n' \
                   '{}\n' \
                   '```\n' \
-                  'The above plugin is not installed.'
+                  'The above plugin or config preset is not installed.'
             return self.problems.add(IssueComment(msg.format(line)))

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -158,7 +158,7 @@ class TestProcessor(TestCase):
         self.fixer_stub.create_context.assert_called()
         self.fixer_stub.run_fixers.assert_called()
         self.tool_stub.run.assert_called()
-        self.fixer_stub.rollback_changes.assert_not_called()
+        self.fixer_stub.rollback_changes.assert_called_with('./tests', pull.head)
         assert 1 == len(subject.problems), 'strategy error adds pull comment'
         assert 0 == subject.problems.error_count(), 'fixer failure should be info level'
         assert 'Unable to apply fixers. ' + str(error) == subject.problems.all()[0].body

--- a/tests/tools/test_eslint.py
+++ b/tests/tools/test_eslint.py
@@ -253,7 +253,7 @@ class TestEslint(TestCase):
         problems = self.problems.all()
         self.assertEqual(1, len(problems))
         self.assertIn('invalid-rules', problems[0].body)
-        self.assertIn('not installed', problems[0].body)
+        self.assertIn('Cannot find module', problems[0].body)
 
         self.assertTrue(docker.image_exists('eslint'),
                         'original image is present')

--- a/tests/tools/test_eslint.py
+++ b/tests/tools/test_eslint.py
@@ -252,7 +252,8 @@ class TestEslint(TestCase):
 
         problems = self.problems.all()
         self.assertEqual(1, len(problems))
-        self.assertIn('Cannot find module', problems[0].body)
+        self.assertIn('invalid-rules', problems[0].body)
+        self.assertIn('not installed', problems[0].body)
 
         self.assertTrue(docker.image_exists('eslint'),
                         'original image is present')


### PR DESCRIPTION
Restore the old branch head when fixer push or commit fails. Right now if the commit works, but the push fails the fix commit is left in place which can cause tools to pass when they shouldn't.