### PR TITLE
Fix file level errors being dropped

### DIFF
--- a/lintreview/diff.py
+++ b/lintreview/diff.py
@@ -171,6 +171,15 @@ class DiffCollection(object):
             return changes[0].line_position(line)
         return None
 
+    def first_changed_line(self, filename):
+        """Get the first changed line in a file diff.
+        """
+        changes = self.all_changes(filename)
+        if len(changes):
+            return changes[0].first_changed_line()
+        return None
+
+
 
 class Diff(object):
     """Contains the changes for a single file.
@@ -269,6 +278,16 @@ class Diff(object):
         for hunk in self._hunks:
             dels = dels.union(hunk.deleted_lines())
         return dels
+
+    def first_changed_line(self):
+        """Get the first changed line in a file diff.
+
+        Useful for repositioning file level errors to the
+        first modified line.
+        """
+        hunk = self._hunks[0]
+        for line in sorted(hunk.added_lines()):
+            return line
 
     def line_position(self, lineno):
         """

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -6,7 +6,7 @@ import six
 
 import lintreview.docker as docker
 
-from lintreview.review import IssueComment
+from lintreview.review import IssueComment, Comment
 from xml.etree import ElementTree
 
 log = logging.getLogger(__name__)
@@ -254,6 +254,8 @@ def process_checkstyle(problems, xml, filename_converter):
             message = err.get('message')
             try:
                 lines = []
+                if line in ('undefined', 'null'):
+                    lines = [Comment.FIRST_LINE_IN_DIFF]
                 if ',' in line:
                     lines = [int(x) for x in line.split(',')]
                 else:

--- a/tests/fixtures/eslint/.eslintignore
+++ b/tests/fixtures/eslint/.eslintignore
@@ -1,0 +1,1 @@
+ignore.js

--- a/tests/fixtures/eslint/ignore.js
+++ b/tests/fixtures/eslint/ignore.js
@@ -1,0 +1,2 @@
+var a = 'this file should be ignored';
+console.log(a);

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -125,6 +125,16 @@ class TestDiffCollection(TestCase):
         self.assertEqual(False, log.warn.called)
         self.assertEqual(False, log.error.called)
 
+    def test_first_changed_line(self):
+        changes = DiffCollection(self.two_files)
+        filename = 'Console/Command/Task/AssetBuildTask.php'
+
+        assert changes.first_changed_line('not there') is None
+        assert changes.first_changed_line(filename) == 117
+
+        filename = "Test/test_files/View/Parse/single.ctp"
+        assert changes.first_changed_line(filename) == 3
+
     def assert_instances(self, collection, count, clazz):
         """
         Helper for checking a collection.
@@ -374,3 +384,12 @@ class TestDiff(TestCase):
         updated = parse_diff(updated)[0]
         intersecting = updated.intersection(original)
         self.assertEqual(2, len(intersecting))
+
+    def test_first_changed_line(self):
+        assert self.diff.first_changed_line() == 454
+
+        data = load_fixture('diff/one_file.txt')
+        out = parse_diff(data)
+
+        change = out.all_changes('tests/test_diff.py')
+        assert change[0].first_changed_line() == 6

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -651,6 +651,31 @@ class TestProblems(TestCase):
         ]
         self.assertEqual(result, expected)
 
+    def test_limit_to_changes__first_line_in_diff(self):
+        res = [
+            PullFile(f, self.session) for f in json.loads(self.two_files_json)
+        ]
+        changes = DiffCollection(res)
+
+        # Add problems
+        filename = 'Test/test_files/View/Parse/single.ctp'
+        errors = (
+            Comment(filename, 5, 5, 'Something bad'),
+            Comment(filename, Comment.FIRST_LINE_IN_DIFF, 0, 'First line!'),
+            Comment(filename, 7, 7, 'Filtered out'),
+        )
+        self.problems.add_many(errors)
+        self.problems.set_changes(changes)
+        self.problems.limit_to_changes()
+
+        result = self.problems.all(filename)
+        self.assertEqual(2, len(result))
+        expected = [
+            Comment(filename, 5, 5, 'Something bad'),
+            Comment(filename, 3, 3, 'First line!'),
+        ]
+        self.assertEqual(result, expected)
+
     def test_has_changes(self):
         problems = Problems(changes=None)
         self.assertFalse(problems.has_changes())


### PR DESCRIPTION
Instead of dropping these warnings as they have line=undefined we can use sigil values to place them on the first added line in a file. If a file only contains deletions the message will still be dropped.