### PR TITLE
Add flake8-isort support

### DIFF
--- a/docker/requirements-py3.txt
+++ b/docker/requirements-py3.txt
@@ -1,5 +1,6 @@
 pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.4.0
+flake8-isort>=2.7.0,<3.0
 autopep8>=1.3.0,<2.0.0
 black==18.6b4
 scikit-build

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,7 @@
 jinja2>=2.10.1
 pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.4.0
+flake8-isort>=2.7.0,<3.0
 yamllint>=1.6.1,<1.7.0
 demjson>=2.2.3,<2.3.0
 ansible-lint>=3.4.11,<3.5.0

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -74,6 +74,8 @@ class Flake8(Tool):
             command.extend(['--format', 'default'])
         else:
             command.append('--isolated')
+        if not self.options.get('isort', False):
+            command.append('--no-isort-config')
         command += files
         return command
 


### PR DESCRIPTION
Add the `isort` option which enable the flake8-isort plugin. Because of how this plugin works it needs to be disabled by default.