### PR TITLE
Add ability to install flake8 plugins

### DIFF
--- a/docker/flake8-install.sh
+++ b/docker/flake8-install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /tool || exit 1
+
+# Install packages in $1 (comma separated) with pip
+for i in $(echo "$1" | sed "s/,/ /g")
+do
+    pip install "$i"
+done

--- a/docker/python2.Dockerfile
+++ b/docker/python2.Dockerfile
@@ -7,9 +7,11 @@ RUN mkdir /src \
   && rm -rf /var/cache/apk/*
 
 COPY requirements.txt /tool
+COPY flake8-install.sh /usr/bin/flake8-install
 
 # Install linters
 RUN cd /tool \
-  && pip install -r requirements.txt
+  && pip install -r requirements.txt \
+  && chmod +x /usr/bin/flake8-install
 
 WORKDIR /src

--- a/docker/python3.Dockerfile
+++ b/docker/python3.Dockerfile
@@ -13,10 +13,12 @@ RUN mkdir /src \
 
 COPY requirements-py3.txt /tool
 COPY merge-pyi-wrapper.sh /usr/bin/merge-pyi-wrapper
+COPY flake8-install.sh /usr/bin/flake8-install
 
 # Install linters & wrapper script
 RUN cd /tool \
   && pip install -r requirements-py3.txt \
-  && chmod +x /usr/bin/merge-pyi-wrapper
+  && chmod +x /usr/bin/merge-pyi-wrapper \
+  && chmod +x /usr/bin/flake8-install
 
 WORKDIR /src

--- a/docker/requirements-py3.txt
+++ b/docker/requirements-py3.txt
@@ -1,6 +1,5 @@
 pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.4.0
-https://github.com/markstory/flake8-isort/archive/7a38cc0d0637bba0d9a57325fdc54462056f636f.tar.gz
 autopep8>=1.3.0,<2.0.0
 black==18.6b4
 scikit-build

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,6 @@
 jinja2>=2.10.1
 pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.4.0
-https://github.com/markstory/flake8-isort/archive/7a38cc0d0637bba0d9a57325fdc54462056f636f.tar.gz
 yamllint>=1.6.1,<1.7.0
 demjson>=2.2.3,<2.3.0
 ansible-lint>=3.4.11,<3.5.0

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import os
 import logging
+import hashlib
 from typing import Dict, List, Optional  # noqa: F401
 
 import six
@@ -202,3 +203,8 @@ def commit(name):
     except (NotFound, APIError):
         log.exception("Exception committing container.")
         raise ValueError("Could not commit container: {0}".format(name))
+
+def generate_container_name(prefix, files):
+    m = hashlib.md5()
+    m.update('-'.join(files).encode('utf8'))
+    return prefix + m.hexdigest()

--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -204,6 +204,7 @@ def commit(name):
         log.exception("Exception committing container.")
         raise ValueError("Could not commit container: {0}".format(name))
 
+
 def generate_container_name(prefix, files):
     m = hashlib.md5()
     m.update('-'.join(files).encode('utf8'))

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import hashlib
+
 import logging
 import os
 import re
@@ -41,8 +41,8 @@ class Eslint(Tool):
         log.debug('Processing %s files with %s', files, self.name)
         command = self._create_command()
         command += files
-        container_name = self._container_name(files)
 
+        container_name = self._container_name(files)
         self.install_plugins(container_name)
         image_name = container_name or 'eslint'
 
@@ -107,16 +107,14 @@ class Eslint(Tool):
         return command
 
     def _container_name(self, files):
-        """Get the persistent container name
+        """Get the persistent container name for custom plugins.
+
         This is only used when we have to install custom plugins
         as that requires creating new temporary images.
         """
         if not self.options.get('install_plugins', False):
             return None
-
-        m = hashlib.md5()
-        m.update('-'.join(files).encode('utf8'))
-        return 'eslint-' + m.hexdigest()
+        return docker.generate_container_name('eslint', files)
 
     def _cleanup(self, container_name):
         """Remove the named container and temporary image

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import logging
 import os
 import re
-import six
 
 import lintreview.docker as docker
 from lintreview.review import IssueComment
@@ -138,7 +137,11 @@ class Flake8(Tool):
             return image
         if not isinstance(plugins, list):
             plugin_type = plugins.__class__.__name__
-            error = IssueComment(u'The `flake8.plugins` option must be a list got `{}` instead.'.format(plugin_type))
+            error = IssueComment(
+                u'The `flake8.plugins` option must be a list got `{}` instead.'.format(
+                    plugin_type
+                )
+            )
             self.problems.add(error)
             return image
 
@@ -158,7 +161,7 @@ class Flake8(Tool):
         if self.custom_image is None:
             log.info('Installing flake8 plugins into %s', container_name)
 
-            output = docker.run(
+            docker.run(
                 image,
                 ['flake8-install', u','.join(plugins)],
                 source_dir=self.base_path,

--- a/tests/fixtures/flake8/has_errors.py
+++ b/tests/fixtures/flake8/has_errors.py
@@ -15,5 +15,7 @@ def thing(self):
 def thing_two(arg1, arg2):
     """Do a second thing that also has errors."""
     result=arg1*arg2
-    if result <> arg1:
+    x = None
+    hasattr(x, '__call__')
+    if result != arg1:
         print('derp')


### PR DESCRIPTION
The approach I took with isort is not going to work longer term. Instead
add the ability to install plugins from an approved list of additional
plugins. This helps accomodate more flake8 usage.