### PR TITLE
Add optional package support for phpcs

### DIFF
--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -9,6 +9,7 @@ RUN apk update \
   && rm -rf /var/cache/apk/*
 
 COPY composer.json /tool
+COPY phpcs-install.sh /usr/bin/phpcs-install
 
 # Get composer, install PHP tools and remove composer.
 RUN cd /tool \
@@ -19,9 +20,9 @@ RUN cd /tool \
   && ln -s /tool/vendor/bin/phpcs /usr/bin/phpcs \
   && ln -s /tool/vendor/bin/phpcbf /usr/bin/phpcbf \
   && ln -s /tool/vendor/bin/phpmd /usr/bin/phpmd \
+  # executable installer script
+  && chmod +x /usr/bin/phpcs-install \
   # Add coding standards to phpcs
-  && vendor/bin/phpcs --config-set installed_paths /tool/vendor/cakephp/cakephp-codesniffer \
-  # cleanup
-  && rm /tool/composer.phar /tool/composer-setup.php /tool/composer.json /tool/composer.lock
+  && vendor/bin/phpcs --config-set installed_paths /tool/vendor/cakephp/cakephp-codesniffer
 
 WORKDIR /src

--- a/docker/phpcs-install.sh
+++ b/docker/phpcs-install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /tool || exit 1
+
+php /tool/composer.phar require "$1"

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -45,10 +45,7 @@ class Phpcs(Tool):
         """
         image = self.get_image_name(files)
         command = self.create_command(files)
-        output = docker.run(
-            'php',
-            command,
-            source_dir=self.base_path)
+        output = docker.run(image, command, source_dir=self.base_path)
 
         # Check for errors from PHPCS
         if output.startswith('ERROR'):

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -5,13 +5,14 @@ import os
 import six
 
 from collections import namedtuple
+
+from lintreview import docker
 from lintreview.review import IssueComment
 from lintreview.tools import (
     Tool,
     process_checkstyle,
     stringify
 )
-import lintreview.docker as docker
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ Package = namedtuple('Package', ['package', 'name'])
 OPTIONAL_PACKAGES = {
     'CakePHP4': Package('cakephp/cakephp-codesniffer:dev-next', 'CakePHP')
 }
+
 
 class Phpcs(Tool):
 
@@ -46,6 +48,7 @@ class Phpcs(Tool):
         image = self.get_image_name(files)
         command = self.create_command(files)
         output = docker.run(image, command, source_dir=self.base_path)
+        self._cleanup()
 
         # Check for errors from PHPCS
         if output.startswith('ERROR'):

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -123,7 +123,8 @@ class Phpcs(Tool):
         If the `standard` option that is an optional package
         the a custom image will be created.
         """
-        image = 'phpcs'
+        image = 'php'
+
         standard = self.options.get('standard', None)
         if not standard or standard not in OPTIONAL_PACKAGES:
             return image

--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -76,6 +76,19 @@ class TestPhpcs(TestCase):
                          'Changing standards changes error counts')
 
     @requires_image('php')
+    def test_process_files__with_optional_package(self):
+        config = {
+            'standard': 'CakePHP4'
+        }
+        tool = Phpcs(self.problems, config, root_dir)
+        tool.process_files([self.fixtures[1]])
+
+        problems = self.problems.all(self.fixtures[1])
+
+        self.assertEqual(3, len(problems),
+                         'Changing standards changes error counts')
+
+    @requires_image('php')
     def test_process_files__with_ignore(self):
         config = {
             'standard': 'PSR2',

--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
+
+from lintreview import docker
 from lintreview.review import Problems, Comment
 from lintreview.tools.phpcs import Phpcs
+
 from unittest import TestCase
 from tests import root_dir, read_file, read_and_restore_file, requires_image
 
@@ -84,8 +87,10 @@ class TestPhpcs(TestCase):
         tool.process_files([self.fixtures[1]])
 
         problems = self.problems.all(self.fixtures[1])
-
         assert 'strict_types' in problems[0].body, 'Should use custom rules'
+
+        for image in docker.images():
+            self.assertNotIn('phpcs-', image, 'no phpcs image remains')
 
     @requires_image('php')
     def test_process_files__with_ignore(self):

--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -85,8 +85,7 @@ class TestPhpcs(TestCase):
 
         problems = self.problems.all(self.fixtures[1])
 
-        self.assertEqual(3, len(problems),
-                         'Changing standards changes error counts')
+        assert 'strict_types' in problems[0].body, 'Should use custom rules'
 
     @requires_image('php')
     def test_process_files__with_ignore(self):


### PR DESCRIPTION
Instead of requiring a larger image with all the standards enable builds to include optional dependencies or newer/older versions of included standards.