### PR TITLE
Tool version updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tags
 /.bundle
 output.log
 go.sum
+response_*

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,9 @@ tag: guard-VERSION
 	python setup.py sdist upload
 
 release: tag
+
+args = $(filter-out $@,$(MAKECMDGOALS))
+
+update: ## Update [tool] to latest release from github
+	$(eval tool = $(args))
+	@./update_tool.sh $(tool)

--- a/update_tool.sh
+++ b/update_tool.sh
@@ -79,5 +79,4 @@ rm -rf "response_${tool}"
 cmd="git checkout -b update-${tool}-version"
 cmd="${cmd} && git add -A"
 cmd="${cmd} && git commit -m \"Update $tool to version $version\""
-#eval ${cmd}
-echo $cmd
+eval ${cmd}

--- a/update_tool.sh
+++ b/update_tool.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+tool=$1
+# switch case tools
+case $tool in
+    checkstyle*)
+        repo="checkstyle/checkstyle"
+        type="docker download"
+    ;;
+    foodcritic)
+        repo="Foodcritic/foodcritic"
+        type="gemfile"
+    ;;
+    goodcheck)
+        repo="sider/goodcheck"
+        type="gemfile"
+    ;;
+    puppet-lint)
+        repo="rodjek/puppet-lint"
+        type="gemfile"
+    ;;
+    rubocop*)
+        repo="rubocop-hq/rubocop"
+        type="gemfile"
+    ;;
+    *)
+        echo "Tool $tool: not found"
+        exit 1
+    ;;
+esac
+
+# Function to grep and get value from github releases
+function clean_up {
+  echo "$1" | grep "$2" | cut -d : -f 2,3 | tr -d \",
+}
+
+# Hit github API, to get latest release
+result=`curl -s https://api.github.com/repos/${repo}/releases/latest > response_${tool}`
+
+# Get values that we need
+tag_name=`clean_up "$(cat response_${tool})" "tag_name"`
+version="${tag_name//[^0-9.]/}"
+download_url=`clean_up "$(cat response_${tool})" "browser_download_url"`
+filename="${download_url##*/}"
+ext="${download_url##*.}"
+rm -rf response_${tool}
+
+# Download latest release, and delete the old one for checkstyle
+if [[ ${type} =~ "download" ]]; then
+  old_file=`find docker -name "${tool}*.jar"`
+  old_file="$(basename $old_file)"
+  rm docker/#{old_file}
+  curl -s -o docker/${filename} -L ${download_url}
+fi
+
+# Update docker / gemfile version
+if [[ ${type} =~ "docker" ]]; then
+  file="docker/${tool}.Dockerfile"
+  sed -i.bak "s/${old_file}/${filename}/g" ${file} && rm "${file}.bak"
+elif [[ ${type} =~ "gemfile" ]]; then
+  sed -i.bak "s/.*${tool}.*/gem '${tool}', '~>${version}'/" docker/Gemfile && rm docker/Gemfile.bak
+fi
+
+# Create new branch, and commit the update
+cmd="git checkout -b update-${tool}-version"
+cmd="${cmd} && git add -A"
+cmd="${cmd} && git commit -m \"Update $tool to version $version\""
+eval ${cmd}

--- a/update_tool.sh
+++ b/update_tool.sh
@@ -7,10 +7,6 @@ case $tool in
     repo="checkstyle/checkstyle"
     type="docker download"
   ;;
-  foodcritic)
-    repo="Foodcritic/foodcritic"
-    type="gemfile"
-  ;;
   goodcheck)
     repo="sider/goodcheck"
     type="gemfile"

--- a/update_tool.sh
+++ b/update_tool.sh
@@ -15,6 +15,11 @@ case $tool in
     repo="sider/goodcheck"
     type="gemfile"
   ;;
+  ktlint)
+    repo="pinterest/ktlint"
+    type="docker"
+    find_string="ARG ktlint_version="
+  ;;
   puppet-lint)
     repo="rodjek/puppet-lint"
     type="gemfile"
@@ -23,10 +28,10 @@ case $tool in
     repo="rubocop-hq/rubocop"
     type="gemfile"
   ;;
-  ktlint)
-    repo="pinterest/ktlint"
+  swiftlint)
+    repo="realm/swiftlint"
     type="docker"
-    find_string="ARG ktlint_version="
+    find_string="FROM norionomura\/swiftlint:"
   ;;
   *)
     echo "Tool $tool: not found"
@@ -78,4 +83,5 @@ rm -rf "response_${tool}"
 cmd="git checkout -b update-${tool}-version"
 cmd="${cmd} && git add -A"
 cmd="${cmd} && git commit -m \"Update $tool to version $version\""
-eval ${cmd}
+#eval ${cmd}
+echo $cmd

--- a/update_tool.sh
+++ b/update_tool.sh
@@ -43,13 +43,13 @@ version="${tag_name//[^0-9.]/}"
 download_url=`clean_up "$(cat response_${tool})" "browser_download_url"`
 filename="${download_url##*/}"
 ext="${download_url##*.}"
-rm -rf response_${tool}
+rm -rf "response_${tool}"
 
 # Download latest release, and delete the old one for checkstyle
 if [[ ${type} =~ "download" ]]; then
   old_file=`find docker -name "${tool}*.jar"`
   old_file="$(basename $old_file)"
-  rm docker/#{old_file}
+  rm "docker/${old_file}"
   curl -s -o docker/${filename} -L ${download_url}
 fi
 


### PR DESCRIPTION
Add shell script to allow update tool version easily.

As of now, to update version of some of the tools, I need to find the latest version manually and find where I need to update the version.

Currently, this script works for updating:

- checkstyle (update the jar, and dockerfile)
- goodcheck (update gemfile)
- ktlint (update variable on dockerfile)
- puppet-lint (update gemfile)
- rubocop (update gemfile)
- swiftlint (update image on dockerfile)

Some are still missing as I'm not sure which files that also need to be updated to make sure it uses the latest version of the tool.

As to use the script

```sh
# Simple shell script call
./update_tool.sh $tool

# Example:
./update_tool.sh checkstyle

# or use Makefile
make update tool=ktlint
or
make update rubocop
```

I tested the script and it works on Mac, maybe should be tested on Linux and Windows too.