### PR TITLE
update rubocop version

### DIFF
--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rubocop', '~>0.49'
+gem 'rubocop', '~>0.78'
 gem 'goodcheck', '~>1.4.0'
 gem 'puppet-lint', '~>2.2'
 gem 'foodcritic', '~>14.0'


### PR DESCRIPTION
Need to update rubocop to latest version, as my `.rubocop.yml` is unrecognized

<img width="574" alt="config" src="https://user-images.githubusercontent.com/4526413/71639640-adcb4b80-2cac-11ea-8f42-e67c22bf9704.png">

But the latest version already migrated the cop config from Metric to Layout for LineLength

https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutlinelength
