### PR TITLE
Fix test rubocop

### DIFF
--- a/docker/eslint.Dockerfile
+++ b/docker/eslint.Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /src \
   # To handle 'not get uid/gid'
   && npm config set unsafe-perm true \
   # Upgrade yarn to get latest release
-  && npm install yarn@latest -g \
+  && npm install yarn@latest --force -g \
   && rm -rf /var/cache/apk/*
 
 COPY eslint-package.json /tool/package.json

--- a/docker/nodejs.Dockerfile
+++ b/docker/nodejs.Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /src \
   # To handle 'not get uid/gid'
   && npm config set unsafe-perm true \
   # Upgrade yarn to get latest release
-  && npm install yarn@latest -g \
+  && npm install yarn@latest --force -g \
   && rm -rf /var/cache/apk/*
 
 COPY package.json /tool

--- a/docker/ruby2.Dockerfile
+++ b/docker/ruby2.Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.6-alpine
 
 RUN mkdir /src \
   && mkdir /tool \

--- a/tests/tools/test_rubocop.py
+++ b/tests/tools/test_rubocop.py
@@ -65,7 +65,7 @@ class TestRubocop(TestCase):
         assert long_line.filename == linty_filename
         assert long_line.line == 3
         assert long_line.position == 3
-        assert 'C: Metrics/LineLength: Line is too long. [82/80]' in long_line.body
+        assert 'C: Layout/LineLength: Line is too long. [82/80]' in long_line.body
 
     @requires_image('ruby2')
     def test_process_files_one_file_fail_display_cop_names__bool(self):
@@ -81,7 +81,7 @@ class TestRubocop(TestCase):
         assert long_line.filename == linty_filename
         assert long_line.line == 3
         assert long_line.position == 3
-        assert 'C: Metrics/LineLength: Line is too long. [82/80]' in long_line.body
+        assert 'C: Layout/LineLength: Line is too long. [82/80]' in long_line.body
 
     @requires_image('ruby2')
     def test_process_files__invalid_rubocop_yml(self):


### PR DESCRIPTION
It seems that this https://github.com/markstory/lint-review/pull/296 travis job fail because of ruby test fail, and it seems it was because of earlier rubocop update, this PR is trying to fix the issue