### PR TITLE
Bump python3 container to 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ images:
 	cd docker && docker build -t nodejs -f nodejs.Dockerfile .
 	cd docker && docker build -t python2 -f python2.Dockerfile .
 	cd docker && docker build -t python3 -f python3.Dockerfile .
+	cd docker && docker build -t pytype -f pytype.Dockerfile .
 	cd docker && docker build -t ruby2 -f ruby2.Dockerfile .
 	cd docker && docker build -t luacheck -f luacheck.Dockerfile .
 	cd docker && docker build -t golint -f golint.Dockerfile .

--- a/docker/python3.Dockerfile
+++ b/docker/python3.Dockerfile
@@ -1,6 +1,6 @@
 # Use debian instead of alpine as ninja (a dep of pytype)
 # doesn't build with musl because of timestamp struct problems
-FROM python:3.7-slim-stretch
+FROM python:3.8-slim-buster
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker/python3.Dockerfile
+++ b/docker/python3.Dockerfile
@@ -1,24 +1,18 @@
-# Use debian instead of alpine as ninja (a dep of pytype)
-# doesn't build with musl because of timestamp struct problems
-FROM python:3.8-slim-buster
-
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    gcc \
-    build-essential \
-  && rm -rf /var/lib/apt/lists/*
+FROM python:3.8-alpine
 
 RUN mkdir /src \
   && mkdir /tool
 
+RUN apk update \
+  && apk add openssl-dev make libc-dev linux-headers gcc libffi-dev \
+  && rm -rf /var/cache/apk/*
+
 COPY requirements-py3.txt /tool
-COPY merge-pyi-wrapper.sh /usr/bin/merge-pyi-wrapper
 COPY flake8-install.sh /usr/bin/flake8-install
 
 # Install linters & wrapper script
 RUN cd /tool \
   && pip install -r requirements-py3.txt \
-  && chmod +x /usr/bin/merge-pyi-wrapper \
   && chmod +x /usr/bin/flake8-install
 
 WORKDIR /src

--- a/docker/pytype-requirements.txt
+++ b/docker/pytype-requirements.txt
@@ -1,0 +1,2 @@
+scikit-build
+pytype==2019.04.19

--- a/docker/pytype.Dockerfile
+++ b/docker/pytype.Dockerfile
@@ -1,0 +1,22 @@
+# Use debian instead of alpine as ninja (a dep of pytype)
+# doesn't build with musl because of timestamp struct problems
+FROM python:3.7-slim-buster
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    gcc \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /src \
+  && mkdir /tool
+
+COPY pytype-requirements.txt /tool
+COPY merge-pyi-wrapper.sh /usr/bin/merge-pyi-wrapper
+
+# Install linters & wrapper script
+RUN cd /tool \
+  && pip install -r pytype-requirements.txt \
+  && chmod +x /usr/bin/merge-pyi-wrapper
+
+WORKDIR /src

--- a/docker/requirements-py3.txt
+++ b/docker/requirements-py3.txt
@@ -2,8 +2,6 @@ pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.8.0
 autopep8>=1.5.0,<2.0.0
 black==18.6b4
-scikit-build
-pytype==2019.04.19
 mypy
 django-stubs
 djangorestframework-stubs

--- a/lintreview/tools/pytype.py
+++ b/lintreview/tools/pytype.py
@@ -15,9 +15,9 @@ class Pytype(Tool):
     name = 'pytype'
 
     def check_dependencies(self):
-        """See if the python3 image exists
+        """See if the pytype image exists
         """
-        return docker.image_exists('python3')
+        return docker.image_exists('pytype')
 
     def match_file(self, filename):
         base = os.path.basename(filename)
@@ -40,7 +40,7 @@ class Pytype(Tool):
         command += files
 
         output = docker.run(
-            'python3',
+            'pytype',
             command,
             source_dir=self.base_path)
         if not output:
@@ -129,7 +129,7 @@ class Pytype(Tool):
         # run in a container that sticks around so we can
         # run merge-pyi on the output files.
         docker.run(
-            'python3',
+            'pytype',
             command,
             source_dir=self.base_path,
             name=container_name)

--- a/tests/tools/test_pytype.py
+++ b/tests/tools/test_pytype.py
@@ -23,12 +23,12 @@ class TestPytype(TestCase):
         self.assertTrue(self.tool.match_file('test.py'))
         self.assertTrue(self.tool.match_file('dir/name/test.py'))
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_process_files__one_file_pass(self):
         self.tool.process_files([self.fixtures[0]])
         self.assertEqual([], self.problems.all(self.fixtures[0]))
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_process_files__one_file_fail(self):
         self.tool.process_files([self.fixtures[1]])
         problems = self.problems.all(self.fixtures[1])
@@ -45,7 +45,7 @@ class TestPytype(TestCase):
             fname, 9, 9, "Invalid __slot__ entry: '1' [bad-slots]")
         self.assertEqual(expected, problems[1])
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_process_files_two_files(self):
         self.tool.process_files(self.fixtures)
 
@@ -65,7 +65,7 @@ class TestPytype(TestCase):
             fname, 9, 9, "Invalid __slot__ entry: '1' [bad-slots]")
         self.assertEqual(expected, problems[1])
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_process_files__config_invalid(self):
         options = {
             'config': 'tests/fixtures/pytype/derp'
@@ -77,7 +77,7 @@ class TestPytype(TestCase):
         self.assertIn('Pytype failed', problems[0].body)
         self.assertIn('config file', problems[0].body)
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_process_files__config(self):
         options = {
             'config': 'tests/fixtures/pytype/pytype.ini'
@@ -97,7 +97,7 @@ class TestPytype(TestCase):
         tool = Pytype(self.problems, {'fixer': True}, root_dir)
         self.assertEqual(True, tool.has_fixer())
 
-    @requires_image('python3')
+    @requires_image('pytype')
     def test_run_fixer(self):
         tool = Pytype(self.problems, {'fixer': True}, root_dir)
 


### PR DESCRIPTION
Upgrade to python 3.8. Doing so will enable mypy, flake8 and other linters to
not fail when they encounter python 3.8+ syntax.
