### PR TITLE
Adding the decode('utf-8') method

### DIFF
--- a/lintreview/github.py
+++ b/lintreview/github.py
@@ -56,7 +56,7 @@ def get_lintrc(repo, ref):
     """
     log.info('Fetching lintrc file')
     response = repo.file_contents('.lintrc', ref)
-    return response.decoded
+    return response.decoded.decode('utf-8')
 
 
 def register_hook(repo, hook_url):


### PR DESCRIPTION
This will fix the problem when trying to send the
lintrc file to celery because the JSON serializer
expects a valid JSON string type instead of bytes
when Python 3.6+ is used.
Ref: #304