### PR TITLE
Handle rubocop configuration warnings better.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,8 +2,8 @@ linters:
   flake8:
     config: ./.flake8
   rubocop: {  }
-ignore:
-  files:
+files:
+  ignore:
     - 'bower_components/*'
     - 'node_modules/*'
     - 'tests/fixtures/black/*'

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -10,3 +10,4 @@ ignore:
     - 'tests/fixtures/pep8/*'
     - 'tests/fixtures/py3k/*'
     - 'tests/fixtures/pytype/*'
+    - 'tests/fixtures/rubocop/*'

--- a/tests/fixtures/rubocop/incompleteconfig/.rubocop.yml
+++ b/tests/fixtures/rubocop/incompleteconfig/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  Include:
+    - '**/Gemfile*'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 16
+
+Naming/FileName:
+  Exclude:
+    - 'Gemfile*'
+
+Style/FrozenStringLiteralComment:
+  Include:
+    - '*.rb'

--- a/tests/fixtures/rubocop/incompleteconfig/has_errors.rb
+++ b/tests/fixtures/rubocop/incompleteconfig/has_errors.rb
@@ -1,0 +1,4 @@
+
+  def trailing_space(thing)
+    trailing_whitespace = 4      
+  end

--- a/tests/tools/test_credo.py
+++ b/tests/tools/test_credo.py
@@ -50,4 +50,3 @@ class TestCredo(TestCase):
         expected = Comment(fname, 1, 1,
                            'Modules should have a @moduledoc tag.')
         self.assertEqual(expected, problems[0])
-        assert False

--- a/tests/tools/test_rubocop.py
+++ b/tests/tools/test_rubocop.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 
-from lintreview.review import Comment, Problems
+from lintreview.review import Problems
 from lintreview.tools.rubocop import Rubocop
 from tests import (
     root_dir, read_file, read_and_restore_file, requires_image
@@ -91,6 +91,20 @@ class TestRubocop(TestCase):
         assert 1 == len(problems)
         assert 'Your rubocop configuration' in problems[0].body
         assert 'expected key while parsing' in problems[0].body
+
+    @requires_image('ruby2')
+    def test_process_files__incomplete_rubocop_yml(self):
+        self.tool.process_files(['tests/fixtures/rubocop/incompleteconfig/has_errors.rb'])
+
+        problems = self.problems.all()
+        assert 4 == len(problems)
+        # Check config warning.
+        assert 'Your rubocop configuration' in problems[0].body
+        assert 'The following cops were added' in problems[0].body
+        assert '- Style/HashEachMethods' in problems[0].body
+
+        # Has other errors too.
+        assert 'C: Missing frozen string literal comment.' in problems[1].body
 
     def test_has_fixer__not_enabled(self):
         tool = Rubocop(self.problems, {}, root_dir)


### PR DESCRIPTION
Improve handling of rubocop warnings. Extract all the leading warnings
from rubocop's output and present them as an issue comment. Continue
processing the rest of the tool output as well. Configuration problems
shouldn't halt result processing.