### PR TITLE
Update logger name.

### DIFF
--- a/lintreview/docker.py
+++ b/lintreview/docker.py
@@ -14,6 +14,7 @@ from docker.errors import (
 from requests.exceptions import ReadTimeout, ConnectionError
 
 log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 # The base path for all docker operations
 DOCKER_BASE = '/src'
@@ -138,8 +139,7 @@ def run(image,                     # type: str
         run_args['user'] = os.getuid()
 
     # Only log the first 15 parameters.
-    log.info('Running container: %s', u' '.join(run_args['command'][0:15]))
-    print(u' '.join(run_args['command'][0:15]))
+    buildlog.info('Running container: %s', u' '.join(run_args['command'][0:15]))
     client = _get_client()
     try:
         container = client.containers.run(**run_args)

--- a/lintreview/git.py
+++ b/lintreview/git.py
@@ -8,6 +8,7 @@ from functools import wraps
 from six.moves.urllib.parse import urlparse, urlunparse
 
 log = logging.getLogger(__name__)
+buildlog = logging.getLogger('build.log')
 
 
 def log_io_error(func):
@@ -16,7 +17,7 @@ def log_io_error(func):
         try:
             return func(*args, **kwargs)
         except IOError as e:
-            log.info(str(e))
+            buildlog.info(str(e))
             raise
     return wrapper
 
@@ -71,13 +72,13 @@ def clone_or_update(config, url, path, head):
     """Clone a new repository and checkout commit,
     or update an existing clone to the new head
     """
-    log.info("Cloning repository '%s' into '%s'", url, path)
+    buildlog.info("Cloning repository '%s' into '%s'", url, path)
     if 'GITHUB_OAUTH_TOKEN' in config:
         authenticated_clone(config, url, path)
     else:
-        log.warn('No github oauth token present. Using public clone.')
+        buildlog.warn('No github oauth token present. Using public clone.')
         clone(url, path)
-    log.info("Checking out '%s'", head)
+    buildlog.info("Checking out '%s'", head)
     checkout(path, head)
 
 

--- a/lintreview/tools/__init__.py
+++ b/lintreview/tools/__init__.py
@@ -10,6 +10,7 @@ from lintreview.review import IssueComment
 from xml.etree import ElementTree
 
 log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 
 class Tool(object):
@@ -45,7 +46,7 @@ class Tool(object):
             log.debug('No matching files for %s', self.name)
             return
 
-        log.info('Running %s on %d files', self.name, num_files)
+        buildlog.info('Running %s on %d files', self.name, num_files)
         log.debug('Processing %s files with %s', matching_files, self.name)
         try:
             self.process_files(matching_files)
@@ -76,7 +77,7 @@ class Tool(object):
         num_files = len(matching_files)
         if not num_files:
             return
-        log.info('Running fixer %s on %d files', self.name, num_files)
+        buildlog.info('Running fixer %s on %d files', self.name, num_files)
         self.process_fixer(matching_files)
 
     def has_fixer(self):
@@ -190,11 +191,10 @@ def run(lint_tools, files, commits):
 
     log.info('Running for %d files', len(files))
     for tool in lint_tools:
-        log.debug('Running %s tool', tool)
         previous_total = len(tool.problems)
         tool.execute(files)
         tool.execute_commits(commits)
-        log.info('Added %s review notes', len(tool.problems) - previous_total)
+        buildlog.info('Added %s review notes', len(tool.problems) - previous_total)
 
 
 def process_quickfix(problems, output, filename_converter, columns=3):

--- a/lintreview/tools/black.py
+++ b/lintreview/tools/black.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool
-
-log = logging.getLogger(__name__)
 
 
 class Black(Tool):

--- a/lintreview/tools/checkstyle.py
+++ b/lintreview/tools/checkstyle.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
-import logging
 import os
 import jprops
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_checkstyle
-
-log = logging.getLogger(__name__)
 
 
 class Checkstyle(Tool):

--- a/lintreview/tools/commitcheck.py
+++ b/lintreview/tools/commitcheck.py
@@ -7,7 +7,6 @@ import re
 
 
 log = logging.getLogger(__name__)
-
 config = load_config()
 
 

--- a/lintreview/tools/credo.py
+++ b/lintreview/tools/credo.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Credo(Tool):
@@ -33,7 +30,6 @@ class Credo(Tool):
         command += files
         output = docker.run('credo', command, self.base_path)
         if not output:
-            log.debug('No credo errors found.')
             return False
 
         process_quickfix(

--- a/lintreview/tools/csslint.py
+++ b/lintreview/tools/csslint.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import
-import logging
 import os
 import re
 import lintreview.docker as docker
 from lintreview.tools import Tool, stringify
-
-
-log = logging.getLogger(__name__)
 
 
 class Csslint(Tool):

--- a/lintreview/tools/eslint.py
+++ b/lintreview/tools/eslint.py
@@ -7,7 +7,7 @@ from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_checkstyle, commalist
 import lintreview.docker as docker
 
-log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 
 class Eslint(Tool):
@@ -74,7 +74,7 @@ class Eslint(Tool):
 
         container_name = docker.generate_container_name('eslint', files)
         if self.custom_image is None:
-            log.info('Installing eslint plugins into %s', container_name)
+            buildlog.info('Installing additional eslint plugins')
             output = docker.run(
                 'eslint',
                 ['eslint-install'],
@@ -90,7 +90,7 @@ class Eslint(Tool):
                 for line in output.splitlines()
                 if line.startswith('add:')
             ]
-            log.info('Installed eslint plugins %s', installed)
+            buildlog.info('Installed eslint plugins %s', installed)
         return container_name
 
     def _create_command(self):
@@ -117,7 +117,7 @@ class Eslint(Tool):
         """
         if self.custom_image is None:
             return
-        log.info('Removing temporary image %s', self.custom_image)
+        buildlog.info('Removing custom eslint image')
         docker.rm_image(self.custom_image)
         self.custom_image = None
 

--- a/lintreview/tools/flake8.py
+++ b/lintreview/tools/flake8.py
@@ -11,7 +11,7 @@ from lintreview.tools import (
     python_image,
 )
 
-log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 
 class Flake8(Tool):
@@ -163,7 +163,7 @@ class Flake8(Tool):
 
         container_name = docker.generate_container_name('flake8', files)
         if self.custom_image is None:
-            log.info('Installing flake8 plugins into %s', container_name)
+            buildlog.info('Installing flake8 plugins')
 
             docker.run(
                 image,
@@ -174,7 +174,7 @@ class Flake8(Tool):
             docker.commit(container_name)
             docker.rm_container(container_name)
             self.custom_image = container_name
-            log.info('Installed flake8 plugins %s', plugins)
+            buildlog.info('Installed flake8 plugins %s', plugins)
 
         return container_name
 
@@ -183,6 +183,6 @@ class Flake8(Tool):
         """
         if self.custom_image is None:
             return
-        log.info('Removing temporary image %s', self.custom_image)
+        buildlog.info('Removing custom flake8 image')
         docker.rm_image(self.custom_image)
         self.custom_image = None

--- a/lintreview/tools/foodcritic.py
+++ b/lintreview/tools/foodcritic.py
@@ -4,8 +4,6 @@ import lintreview.docker as docker
 
 from lintreview.tools import Tool
 
-log = logging.getLogger(__name__)
-
 
 class Foodcritic(Tool):
 
@@ -28,7 +26,6 @@ class Foodcritic(Tool):
         output = docker.run('ruby2', command, self.base_path)
 
         if output[0] == '\n':
-            log.debug('No foodcritic errors found.')
             return False
 
         for line in output.split("\n"):
@@ -42,7 +39,6 @@ class Foodcritic(Tool):
         foodcritic only generates results as stdout.
         Parse the output for real data.
         """
-        log.debug('Line: %s' % line)
         parts = line.split(': ')
 
         filename = parts[2].split(':')[0].strip()

--- a/lintreview/tools/gpg.py
+++ b/lintreview/tools/gpg.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
-import logging
 
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool
-
-log = logging.getLogger(__name__)
 
 
 class Gpg(Tool):

--- a/lintreview/tools/jshint.py
+++ b/lintreview/tools/jshint.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
-import logging
 import os
 from lintreview.tools import Tool, process_checkstyle
 import lintreview.docker as docker
-
-log = logging.getLogger(__name__)
 
 
 class Jshint(Tool):

--- a/lintreview/tools/jsonlint.py
+++ b/lintreview/tools/jsonlint.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Jsonlint(Tool):
@@ -37,7 +34,6 @@ class Jsonlint(Tool):
             command,
             source_dir=self.base_path)
         if not output:
-            log.debug('No jsonlint errors found.')
             return False
 
         output = output.split("\n")

--- a/lintreview/tools/ktlint.py
+++ b/lintreview/tools/ktlint.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
-import logging
 import os
 import lintreview.docker as docker
 from lintreview.tools import Tool, process_checkstyle
-
-log = logging.getLogger(__name__)
 
 
 class Ktlint(Tool):

--- a/lintreview/tools/luacheck.py
+++ b/lintreview/tools/luacheck.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
-import logging
 import os
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Luacheck(Tool):

--- a/lintreview/tools/mypy.py
+++ b/lintreview/tools/mypy.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix, stringify
-
-log = logging.getLogger(__name__)
 
 
 class Mypy(Tool):
@@ -35,7 +32,6 @@ class Mypy(Tool):
 
         output = docker.run('python3', command, source_dir=self.base_path)
         if not output:
-            log.debug('No mypy errors found.')
             return False
         output = output.strip().split("\n")
         if len(output) and output[-1].startswith('mypy: error:'):

--- a/lintreview/tools/pep8.py
+++ b/lintreview/tools/pep8.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.tools import Tool, process_quickfix, python_image
-
-log = logging.getLogger(__name__)
 
 
 class Pep8(Tool):
@@ -48,7 +45,6 @@ class Pep8(Tool):
         image = python_image(self.options)
         output = docker.run(image, command, source_dir=self.base_path)
         if not output:
-            log.debug('No pep8 errors found.')
             return False
         output = output.split("\n")
 

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os
 import six
+import logging
 
 from collections import namedtuple
 
@@ -156,6 +157,7 @@ class Phpcs(Tool):
             docker.rm_container(container_name)
             self.custom_image = container_name
             buildlog.info('Installed phpcs package %s', standard)
+            foooo
 
         return container_name
 

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import logging
 import os
 import six
 
@@ -14,7 +13,7 @@ from lintreview.tools import (
     stringify
 )
 
-log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 Package = namedtuple('Package', ['package', 'name'])
 
@@ -145,7 +144,7 @@ class Phpcs(Tool):
 
         container_name = docker.generate_container_name('phpcs-', files)
         if self.custom_image is None:
-            log.info('Installing phpcs package into %s', container_name)
+            buildlog.info('Installing phpcs package')
 
             docker.run(
                 image,
@@ -156,7 +155,7 @@ class Phpcs(Tool):
             docker.commit(container_name)
             docker.rm_container(container_name)
             self.custom_image = container_name
-            log.info('Installed phpcs package %s', standard)
+            buildlog.info('Installed phpcs package %s', standard)
 
         return container_name
 
@@ -165,6 +164,6 @@ class Phpcs(Tool):
         """
         if self.custom_image is None:
             return
-        log.info('Removing temporary image %s', self.custom_image)
+        buildlog.info('Removing custom phpcs image')
         docker.rm_image(self.custom_image)
         self.custom_image = None

--- a/lintreview/tools/phpcs.py
+++ b/lintreview/tools/phpcs.py
@@ -157,7 +157,6 @@ class Phpcs(Tool):
             docker.rm_container(container_name)
             self.custom_image = container_name
             buildlog.info('Installed phpcs package %s', standard)
-            foooo
 
         return container_name
 

--- a/lintreview/tools/phpmd.py
+++ b/lintreview/tools/phpmd.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import logging
 import os
 from lintreview.review import IssueComment
 from lintreview.tools import (
@@ -7,8 +6,6 @@ from lintreview.tools import (
     process_pmd
 )
 import lintreview.docker as docker
-
-log = logging.getLogger(__name__)
 
 
 class Phpmd(Tool):

--- a/lintreview/tools/puppet.py
+++ b/lintreview/tools/puppet.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Puppet(Tool):
@@ -31,7 +28,6 @@ class Puppet(Tool):
         output = docker.run('ruby2', command, self.base_path)
 
         if not output:
-            log.debug('No puppet-lint errors found.')
             return False
 
         output = output.split("\n")

--- a/lintreview/tools/py3k.py
+++ b/lintreview/tools/py3k.py
@@ -5,7 +5,7 @@ import lintreview.docker as docker
 import re
 from lintreview.tools import Tool, process_quickfix, stringify
 
-log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 
 class Py3k(Tool):
@@ -37,7 +37,6 @@ class Py3k(Tool):
         command = self.make_command(files)
         output = docker.run('python2', command, self.base_path)
         if not output:
-            log.debug('No py3k errors found.')
             return False
 
         output = output.split("\n")
@@ -66,7 +65,7 @@ class Py3k(Tool):
         for option in self.options:
             if option in accepted_options:
                 continue
-            log.warning('Set non-existent py3k option: %s', option)
+            buildlog.warning('Set non-existent py3k option: %s', option)
         command.extend(files)
         return command
 

--- a/lintreview/tools/pytype.py
+++ b/lintreview/tools/pytype.py
@@ -7,7 +7,7 @@ import lintreview.docker as docker
 from lintreview.tools import Tool
 from lintreview.review import IssueComment
 
-log = logging.getLogger(__name__)
+buildlog = logging.getLogger('buildlog')
 
 
 class Pytype(Tool):
@@ -133,7 +133,7 @@ class Pytype(Tool):
             source_dir=self.base_path,
             name=container_name)
 
-        log.info('Creating temporary image for %s', container_name)
+        buildlog.info('Creating cusotm image for pytype')
         docker.commit(container_name)
         docker.rm_container(container_name)
 
@@ -148,7 +148,7 @@ class Pytype(Tool):
                 source_dir=self.base_path
             )
         except Exception as e:
-            log.warning('Pytype merging failed. error=%s output=%s', e, out)
+            buildlog.warning('Pytype merging failed. error=%s output=%s', e, out)
         finally:
-            log.info('Removing temporary image for %s', container_name)
+            buildlog.info('Removing custom pytype image')
             docker.rm_image(container_name)

--- a/lintreview/tools/remarklint.py
+++ b/lintreview/tools/remarklint.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
-import logging
 import os
 import re
 
 import lintreview.docker as docker
 from lintreview.tools import Tool
-
-log = logging.getLogger(__name__)
 
 # matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
 # matches: '  18:71-19:1  error  Missing new line after list item  list-item-spacing  remark-lint',

--- a/lintreview/tools/rubocop.py
+++ b/lintreview/tools/rubocop.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Rubocop(Tool):

--- a/lintreview/tools/sasslint.py
+++ b/lintreview/tools/sasslint.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
-import logging
 import os
 from lintreview.tools import Tool, process_checkstyle
 import lintreview.docker as docker
-
-
-log = logging.getLogger(__name__)
 
 
 class Sasslint(Tool):

--- a/lintreview/tools/shellcheck.py
+++ b/lintreview/tools/shellcheck.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
-import logging
 import os
 import lintreview.docker as docker
 from lintreview.tools import Tool,  process_checkstyle
 from six.moves import map
-
-log = logging.getLogger(__name__)
 
 
 class Shellcheck(Tool):

--- a/lintreview/tools/standardjs.py
+++ b/lintreview/tools/standardjs.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
-import logging
 import os
 from lintreview.tools import Tool, process_quickfix
 import lintreview.docker as docker
-
-log = logging.getLogger(__name__)
 
 
 class Standardjs(Tool):

--- a/lintreview/tools/stylelint.py
+++ b/lintreview/tools/stylelint.py
@@ -1,13 +1,9 @@
 from __future__ import absolute_import
-import logging
 import os
 
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix
 import lintreview.docker as docker
-
-
-log = logging.getLogger(__name__)
 
 
 class Stylelint(Tool):

--- a/lintreview/tools/swiftlint.py
+++ b/lintreview/tools/swiftlint.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
-import logging
 import os
 
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_checkstyle
-
-log = logging.getLogger(__name__)
 
 
 class Swiftlint(Tool):

--- a/lintreview/tools/tslint.py
+++ b/lintreview/tools/tslint.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
-import logging
 import os
 import re
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_checkstyle
 import lintreview.docker as docker
-
-log = logging.getLogger(__name__)
 
 
 class Tslint(Tool):

--- a/lintreview/tools/yamllint.py
+++ b/lintreview/tools/yamllint.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 import os
-import logging
 import lintreview.docker as docker
 from lintreview.review import IssueComment
 from lintreview.tools import Tool, process_quickfix
-
-log = logging.getLogger(__name__)
 
 
 class Yamllint(Tool):
@@ -42,7 +39,6 @@ class Yamllint(Tool):
 
         output = docker.run('python2', command, self.base_path)
         if not output:
-            log.debug('No yamllint errors found.')
             return False
 
         if 'No such file' in output and 'Traceback' in output:


### PR DESCRIPTION
Use a consistent logger name for various 'build' operations. This will
enable specific log handlers to be attached so that logs can be
captured and sent to another destination.