### PR TITLE
Remove local diff generation

### DIFF
--- a/lintreview/git.py
+++ b/lintreview/git.py
@@ -109,20 +109,6 @@ def diff(path, files=None):
 
 
 @log_io_error
-def diff_commit_range(path, base, head):
-    """Get a diff between the base and head commit.
-
-    Use lintreview.diff.parse_diff if you need to create
-    objects out of the diff output.
-    """
-    command = ['git', 'diff', '--find-renames', '{}...{}'.format(base, head)]
-    return_code, output = _process(command, chdir=path)
-    if return_code:
-        raise IOError(u"Unable to generate diff '{}'".format(output))
-    return output
-
-
-@log_io_error
 def apply_cached(path, patch):
     """Apply a patch to the index.
 

--- a/lintreview/processor.py
+++ b/lintreview/processor.py
@@ -37,17 +37,6 @@ class Processor(object):
         self._changes = DiffCollection(files)
         self.problems.set_changes(self._changes)
 
-    def parse_local_changes(self):
-        head = self._pull_request.head
-        base = self._pull_request.base
-
-        diff_text = git.diff_commit_range(self._target_path, base, head)
-        return parse_diff(diff_text)
-
-    def parse_changes(self):
-        self._changes = self.parse_local_changes()
-        self.problems.set_changes(self._changes)
-
     def execute(self):
         """
         Run the review and return the completed review.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ pytest-cov~=2.6
 mock~=2.0
 codecov
 coverage
+urllib3>=1.25.10,<1.27.0
 responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==1.1.1
 github3.py==1.3.0
-celery==4.3.0
+celery==4.4.7
+vine>1.3.0,<5.0.0
 gunicorn==19.5.0
 argparse>=1.2.0,<=1.3.0
 jprops==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.1
 github3.py==1.3.0
 celery==4.4.7
-vine>1.3.0,<5.0.0
+vine==1.3.0
 gunicorn==19.5.0
 argparse>=1.2.0,<=1.3.0
 jprops==2.0.2

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,9 +1,10 @@
-from . import load_fixture
-from lintreview.diff import DiffCollection, Diff, parse_diff, ParseError
+import re
+
 from unittest import TestCase
 from mock import patch
 
-import re
+from . import load_fixture, create_pull_files
+from lintreview.diff import DiffCollection, Diff, parse_diff, ParseError
 
 
 class TestDiffCollection(TestCase):
@@ -22,6 +23,14 @@ class TestDiffCollection(TestCase):
     single_line_add = load_fixture('diff/diff_single_line_add.txt')
 
     new_empty_file = load_fixture('diff/new_empty_file.txt')
+
+    one_file_json = load_fixture('one_file_pull_request.json')
+
+    def test_constructor_one_file(self):
+        patches = create_pull_files(self.one_file_json)
+        changes = DiffCollection(patches)
+        self.assertEqual(1, len(changes))
+        self.assert_instances(changes, 1, Diff)
 
     def test_create_one_element(self):
         changes = parse_diff(self.one_file)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -119,20 +119,6 @@ class TestGit(TestCase):
             path
         )
 
-    def test_diff_commit_range(self):
-        result = git.diff_commit_range(
-            clone_path,
-            'aa7a9d074132280b54c0eee67221bb955adaaeaf',
-            'c02fb764459f040c8007afa97479fedaf8587866'
-        )
-        assert 'lintreview/tools/rubocop.py' in result
-        assert 'tests/tools/test_rubocop.py' in result
-
-    def test_diff_commit_range__invalid(self):
-        with pytest.raises(IOError) as err:
-            git.diff_commit_range(root_dir, 'bad', 'nope')
-        assert 'unknown revision' in str(err)
-
     @pytest.mark.skipif(cant_write_to_test, reason='Cannot write to ./tests skipping')
     def test_apply_cached(self):
         with open(clone_path + '/README.mdown', 'w') as f:

--- a/tests/tools/test_rubocop.py
+++ b/tests/tools/test_rubocop.py
@@ -103,7 +103,7 @@ class TestRubocop(TestCase):
         # Check config warning.
         assert 'Your rubocop configuration' in problems[0].body
         assert 'The following cops were added' in problems[0].body
-        assert '- Style/HashEachMethods' in problems[0].body
+        assert 'Style/StringConcatenation' in problems[0].body
 
         # Has other errors too.
         assert 'C: Missing frozen string literal comment.' in problems[1].body


### PR DESCRIPTION
It hasn't worked out well. Because the head and base branch can diverge
by more than the shallow clone depth local diff generation often fails
on larger busy repositories. Using local diffs would require cloning the
entire history which is far too slow compared to the network requests to
fetch changes from github. While fetching changes from Github can be
slow it is generally faster than cloning multi GB repositories.