### PR TITLE
Update python3 black linter to 20.8b1

### DIFF
--- a/docker/requirements-py3.txt
+++ b/docker/requirements-py3.txt
@@ -1,7 +1,7 @@
 pep8>=1.7.0,<2.0.0
 flake8>=3.3.0,<3.8.0
 autopep8>=1.5.0,<2.0.0
-black==18.6b4
+black==20.8b1
 mypy
 django-stubs
 djangorestframework-stubs


### PR DESCRIPTION
There are some large differences in style between 20.8b1 and 18.6b4. An engineering team I support went around in circles trying to figure out why the review bot didn't like some code that was formatted with the more recent version of black.